### PR TITLE
fix(connection): buffer BEGIN/COMMIT into single RPC on v3

### DIFF
--- a/src/surql/connection/transaction.py
+++ b/src/surql/connection/transaction.py
@@ -1,4 +1,34 @@
-"""Transaction support for database operations."""
+"""Transaction support for database operations.
+
+Implementation decision (bug #13, option b)
+==========================================
+
+SurrealDB v3 treats each ``query()`` RPC as a standalone request, so
+sending ``BEGIN TRANSACTION`` / ``COMMIT TRANSACTION`` /
+``CANCEL TRANSACTION`` as three separate ``execute()`` calls fails on
+v3 servers with "no transaction is currently open" when the bare
+``COMMIT`` lands. The ``surrealdb`` Python SDK at the pinned version
+(``2.0.0a1``) does not yet expose an interactive ``begin()`` /
+``commit(txn_id)`` API (option a in the original audit), so this class
+buffers queued statements client-side and flushes them as a single
+atomic
+``BEGIN TRANSACTION; <stmts>; COMMIT TRANSACTION;`` request when
+[`Transaction.commit`] is invoked. [`Transaction.cancel`] simply drops
+the buffered statements without contacting the server. This mirrors
+the rs port's approach (see ``surql-rs/src/connection/transaction.rs``)
+and keeps cross-port semantics identical.
+
+Consequences of option (b):
+
+- Results from individual in-transaction statements are not available
+  until ``commit`` returns. ``Transaction.execute`` therefore returns
+  ``None`` at call time; the aggregate response can be obtained via
+  ``commit``'s return value if callers need it.
+- Parameter names across queued statements share one flat namespace
+  (the SDK exposes a single ``vars`` dict per request). Callers must
+  choose unique parameter keys across their queued statements inside
+  the same transaction block.
+"""
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -33,7 +63,9 @@ class TransactionError(Exception):
 class Transaction:
   """Transaction context manager for SurrealDB operations.
 
-  Provides ACID transaction support using SurrealDB's BEGIN/COMMIT/CANCEL statements.
+  Buffers queued statements client-side and flushes them atomically on
+  ``commit``. See module docstring for why the single-flush strategy
+  is required on SurrealDB v3.
   """
 
   def __init__(self, client: DatabaseClient) -> None:
@@ -44,6 +76,8 @@ class Transaction:
     """
     self._client = client
     self._state = TransactionState.PENDING
+    self._statements: list[str] = []
+    self._params: dict[str, Any] = {}
     self._log = logger.bind(transaction_id=id(self))
 
   @property
@@ -59,6 +93,10 @@ class Transaction:
   async def begin(self) -> None:
     """Begin the transaction.
 
+    Does not contact the server; simply flips the state machine so
+    subsequent [`execute`][surql.connection.transaction.Transaction.execute]
+    calls can queue statements.
+
     Raises:
       TransactionError: If transaction is already active, nested, or cannot be started
     """
@@ -68,18 +106,20 @@ class Transaction:
     if _active_transaction.get():
       raise TransactionError('Nested transactions are not supported by SurrealDB')
 
-    try:
-      self._log.info('beginning_transaction')
-      await self._client.execute('BEGIN TRANSACTION;')
-      self._state = TransactionState.ACTIVE
-      _active_transaction.set(True)
-      self._log.info('transaction_started')
-    except Exception as e:
-      self._log.error('transaction_begin_failed', error=str(e))
-      raise TransactionError(f'Failed to begin transaction: {e}') from e
+    self._log.info('beginning_transaction')
+    self._state = TransactionState.ACTIVE
+    _active_transaction.set(True)
+    self._log.info('transaction_started')
 
-  async def commit(self) -> None:
+  async def commit(self) -> Any:
     """Commit the transaction.
+
+    Flushes buffered statements as a single
+    ``BEGIN TRANSACTION; ...; COMMIT TRANSACTION;`` request.
+
+    Returns:
+      The aggregate result of the batched query, or ``None`` when no
+      statements were queued.
 
     Raises:
       TransactionError: If transaction is not active or commit fails
@@ -87,12 +127,25 @@ class Transaction:
     if self._state != TransactionState.ACTIVE:
       raise TransactionError(f'Cannot commit transaction in {self._state.value} state')
 
+    if not self._statements:
+      # Nothing to flush; treat as a successful no-op commit.
+      self._log.info('committing_empty_transaction')
+      self._state = TransactionState.COMMITTED
+      _active_transaction.set(False)
+      return None
+
+    batched = 'BEGIN TRANSACTION;\n'
+    for stmt in self._statements:
+      batched += stmt.rstrip(';') + ';\n'
+    batched += 'COMMIT TRANSACTION;'
+
     try:
-      self._log.info('committing_transaction')
-      await self._client.execute('COMMIT TRANSACTION;')
+      self._log.info('committing_transaction', statement_count=len(self._statements))
+      result = await self._client.execute(batched, self._params or None)
       self._state = TransactionState.COMMITTED
       _active_transaction.set(False)
       self._log.info('transaction_committed')
+      return result
     except Exception as e:
       self._log.error('transaction_commit_failed', error=str(e))
       self._state = TransactionState.CANCELLED
@@ -101,6 +154,9 @@ class Transaction:
 
   async def cancel(self) -> None:
     """Cancel/rollback the transaction.
+
+    Buffered statements are discarded client-side; no server request
+    is made (nothing was sent yet).
 
     Raises:
       TransactionError: If transaction cannot be cancelled
@@ -112,38 +168,50 @@ class Transaction:
       )
       return
 
-    try:
-      self._log.info('cancelling_transaction')
-      if self._state == TransactionState.ACTIVE:
-        await self._client.execute('CANCEL TRANSACTION;')
-      self._state = TransactionState.CANCELLED
-      _active_transaction.set(False)
-      self._log.info('transaction_cancelled')
-    except Exception as e:
-      self._log.error('transaction_cancel_failed', error=str(e))
-      self._state = TransactionState.CANCELLED
-      _active_transaction.set(False)
-      raise TransactionError(f'Failed to cancel transaction: {e}') from e
+    self._log.info('cancelling_transaction')
+    self._statements.clear()
+    self._params.clear()
+    self._state = TransactionState.CANCELLED
+    _active_transaction.set(False)
+    self._log.info('transaction_cancelled')
 
-  async def execute(self, query: str, params: dict[str, Any] | None = None) -> Any:
-    """Execute a query within the transaction context.
+  async def execute(self, query: str, params: dict[str, Any] | None = None) -> None:
+    """Queue a statement for execution inside the transaction.
+
+    The statement is **not** executed until
+    [`commit`][surql.connection.transaction.Transaction.commit] flushes
+    the buffered batch. Returns ``None`` at call time; the aggregate
+    response is available from ``commit``'s return value.
 
     Args:
       query: SurrealQL query string
-      params: Optional query parameters
-
-    Returns:
-      Query results
+      params: Optional query parameters. These are merged into a
+        shared namespace across all queued statements in this
+        transaction; duplicate keys are rejected.
 
     Raises:
-      TransactionError: If transaction is not active
-      QueryError: If query execution fails
+      TransactionError: If transaction is not active, or if ``params``
+        overwrite an already-queued parameter key.
     """
     if not self.is_active:
       raise TransactionError(f'Cannot execute query in {self._state.value} state')
 
-    self._log.debug('executing_query_in_transaction', query=query)
-    return await self._client.execute(query, params)
+    if params:
+      overlap = set(params) & set(self._params)
+      if overlap:
+        raise TransactionError(
+          f'Duplicate transaction parameter names: {sorted(overlap)}. '
+          'All queued statements share one `vars` namespace; rename to disambiguate.'
+        )
+      self._params.update(params)
+
+    self._statements.append(query)
+    self._log.debug(
+      'queued_query_in_transaction',
+      query=query,
+      queued_count=len(self._statements),
+    )
+    return None
 
   async def __aenter__(self) -> 'Transaction':
     """Async context manager entry."""

--- a/src/surql/migration/executor.py
+++ b/src/surql/migration/executor.py
@@ -92,9 +92,16 @@ async def execute_migration(
     # Execute statements within a transaction for atomicity on remote
     # connections. Embedded engines skip the wrapper (see
     # _is_embedded_client note at module top).
+    #
+    # Bug #13 note: SurrealDB v3 treats every `execute()` as a
+    # standalone RPC, so emitting BEGIN/COMMIT/CANCEL as three separate
+    # calls fails with "no transaction is currently open" on the bare
+    # COMMIT. Batch the whole migration into a single
+    # `BEGIN TRANSACTION; <stmts>; COMMIT TRANSACTION;` query so the
+    # transaction lifecycle lives inside one request.
     embedded = _is_embedded_client(client)
 
-    async def _run_statements() -> None:
+    async def _run_statements_individually() -> None:
       for i, statement in enumerate(statements):
         try:
           log.debug('executing_statement', statement_index=i, statement=statement)
@@ -112,18 +119,26 @@ async def execute_migration(
 
     if embedded:
       log.debug('migration_transaction_skipped', reason='embedded_connection')
-      await _run_statements()
+      await _run_statements_individually()
     else:
-      await client.execute('BEGIN TRANSACTION;')
+      batched = 'BEGIN TRANSACTION;\n'
+      for statement in statements:
+        batched += statement.rstrip().rstrip(';') + ';\n'
+      batched += 'COMMIT TRANSACTION;'
       try:
-        await _run_statements()
-        await client.execute('COMMIT TRANSACTION;')
-      except BaseException:
-        try:
-          await client.execute('CANCEL TRANSACTION;')
-        except Exception as cancel_err:
-          log.error('transaction_cancel_failed', error=str(cancel_err))
-        raise
+        log.debug(
+          'executing_batched_migration_transaction',
+          statement_count=len(statements),
+        )
+        await client.execute(batched)
+      except QueryError as e:
+        log.error('batched_migration_failed', error=str(e))
+        # A failed batched transaction is already rolled back server-
+        # side (the query layer aborts on the first failing statement);
+        # no explicit CANCEL is needed.
+        raise MigrationExecutionError(
+          f'Failed to execute migration {migration.version}: {e}'
+        ) from e
 
     # Calculate execution time
     execution_time_ms = int((time.time() - start_time) * 1000)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -483,14 +483,22 @@ class TestTransaction:
 
   @pytest.mark.anyio
   async def test_begin_success(self, mock_db_client: DatabaseClient) -> None:
-    """Test successful transaction begin."""
+    """Test successful transaction begin.
+
+    With the bug #13 buffer strategy, ``begin()`` no longer contacts
+    the server -- it just flips the state machine so statements can
+    be queued.
+    """
     txn = Transaction(mock_db_client)
 
     await txn.begin()
 
     assert txn.state == TransactionState.ACTIVE
     assert txn.is_active is True
-    mock_db_client._client.query.assert_called()
+    # Crucially, `begin` does NOT send a bare "BEGIN TRANSACTION"
+    # RPC. v3 would accept it, but then the matching bare "COMMIT"
+    # would land in a fresh request and be rejected.
+    mock_db_client._client.query.assert_not_called()
 
   @pytest.mark.anyio
   async def test_begin_already_active(self, mock_db_client: DatabaseClient) -> None:
@@ -505,14 +513,25 @@ class TestTransaction:
 
   @pytest.mark.anyio
   async def test_commit_success(self, mock_db_client: DatabaseClient) -> None:
-    """Test successful transaction commit."""
+    """Test successful transaction commit flushes buffered statements."""
     txn = Transaction(mock_db_client)
     await txn.begin()
+    await txn.execute('CREATE user:alice SET name = "Alice"')
+    await txn.execute('CREATE user:bob SET name = "Bob"')
 
     await txn.commit()
 
     assert txn.state == TransactionState.COMMITTED
     assert txn.is_active is False
+
+    # Buffered statements must be flushed as a single batched query
+    # wrapped in BEGIN TRANSACTION ... COMMIT TRANSACTION.
+    mock_db_client._client.query.assert_called_once()
+    batched = mock_db_client._client.query.call_args.args[0]
+    assert batched.startswith('BEGIN TRANSACTION;')
+    assert batched.rstrip().endswith('COMMIT TRANSACTION;')
+    assert 'CREATE user:alice' in batched
+    assert 'CREATE user:bob' in batched
 
   @pytest.mark.anyio
   async def test_commit_not_active(self, mock_db_client: DatabaseClient) -> None:
@@ -529,6 +548,7 @@ class TestTransaction:
     """Test transaction commit failure."""
     txn = Transaction(mock_db_client)
     await txn.begin()
+    await txn.execute('CREATE user:alice')
 
     mock_db_client._client.query = AsyncMock(side_effect=Exception('Commit failed'))
 
@@ -569,14 +589,23 @@ class TestTransaction:
     assert txn.state == TransactionState.COMMITTED
 
   @pytest.mark.anyio
-  async def test_execute_in_transaction(self, mock_db_client: DatabaseClient) -> None:
-    """Test executing query in transaction context."""
+  async def test_execute_queues_without_server_call(self, mock_db_client: DatabaseClient) -> None:
+    """Regression (bug #13): ``execute`` buffers; no RPC until commit.
+
+    Pre-patch, each ``Transaction.execute`` forwarded live to
+    ``client.execute``. SurrealDB v3 treats each RPC as standalone so
+    the matching bare ``COMMIT`` would later be rejected. The new
+    design queues statements and flushes them atomically at commit.
+    """
     txn = Transaction(mock_db_client)
     await txn.begin()
+    mock_db_client._client.query.reset_mock()
 
     result = await txn.execute('CREATE user:alice SET name = "Alice"')
 
-    assert result is not None
+    # No server RPC yet -- purely a buffer append.
+    assert result is None
+    mock_db_client._client.query.assert_not_called()
 
   @pytest.mark.anyio
   async def test_execute_not_active(self, mock_db_client: DatabaseClient) -> None:
@@ -587,6 +616,67 @@ class TestTransaction:
       await txn.execute('SELECT * FROM user')
 
     assert 'Cannot execute query' in str(exc_info.value)
+
+  @pytest.mark.anyio
+  async def test_commit_sends_single_batched_rpc(self, mock_db_client: DatabaseClient) -> None:
+    """Regression (bug #13): commit sends exactly one RPC.
+
+    Pre-patch ``begin``/``commit`` each issued their own ``execute``
+    call. On v3, the standalone ``COMMIT`` in the second RPC fails
+    with 'no transaction is currently open'. The batched
+    ``BEGIN ...; stmts; COMMIT;`` must all land in a single query.
+    """
+    txn = Transaction(mock_db_client)
+    async with txn:
+      await txn.execute('UPDATE user:alice SET x = 1')
+      await txn.execute('UPDATE user:bob   SET x = 2')
+
+    # Exactly one RPC on the wire, wrapped in BEGIN/COMMIT.
+    assert mock_db_client._client.query.call_count == 1
+    batched = mock_db_client._client.query.call_args.args[0]
+    assert batched.count('BEGIN TRANSACTION') == 1
+    assert batched.count('COMMIT TRANSACTION') == 1
+
+  @pytest.mark.anyio
+  async def test_commit_merges_params_across_statements(
+    self, mock_db_client: DatabaseClient
+  ) -> None:
+    """Queued statement params are merged into a single vars dict."""
+    txn = Transaction(mock_db_client)
+    await txn.begin()
+    await txn.execute('UPDATE user:alice SET name = $n1', {'n1': 'Alice'})
+    await txn.execute('UPDATE user:bob   SET name = $n2', {'n2': 'Bob'})
+    await txn.commit()
+
+    params = mock_db_client._client.query.call_args.args[1]
+    assert params == {'n1': 'Alice', 'n2': 'Bob'}
+
+  @pytest.mark.anyio
+  async def test_duplicate_param_keys_rejected(self, mock_db_client: DatabaseClient) -> None:
+    """Duplicate param names across queued statements raise early."""
+    txn = Transaction(mock_db_client)
+    await txn.begin()
+    await txn.execute('UPDATE user:alice SET x = $v', {'v': 1})
+
+    with pytest.raises(TransactionError) as exc_info:
+      await txn.execute('UPDATE user:bob SET x = $v', {'v': 2})
+
+    assert 'Duplicate transaction parameter names' in str(exc_info.value)
+
+  @pytest.mark.anyio
+  async def test_cancel_does_not_contact_server(self, mock_db_client: DatabaseClient) -> None:
+    """``cancel`` drops the buffer; no CANCEL RPC is issued."""
+    txn = Transaction(mock_db_client)
+    await txn.begin()
+    await txn.execute('CREATE user:alice')
+    mock_db_client._client.query.reset_mock()
+
+    await txn.cancel()
+
+    # Nothing was sent to the server, and the buffer is empty.
+    mock_db_client._client.query.assert_not_called()
+    assert txn._statements == []
+    assert txn.state == TransactionState.CANCELLED
 
   @pytest.mark.anyio
   async def test_transaction_context_manager_success(self, mock_db_client: DatabaseClient) -> None:

--- a/tests/test_migration_executor.py
+++ b/tests/test_migration_executor.py
@@ -43,8 +43,15 @@ class TestExecuteMigration:
       assert isinstance(result, int)
       assert result >= 0
 
-      # Verify SQL statements were executed (BEGIN + 2 statements + COMMIT = 4)
-      assert mock_db_client._client.query.call_count == 4
+      # Bug #13: whole migration is flushed as a single batched
+      # BEGIN...;stmts;COMMIT RPC, so v3 never sees a bare COMMIT in a
+      # standalone request.
+      assert mock_db_client._client.query.call_count == 1
+      batched = mock_db_client._client.query.call_args.args[0]
+      assert batched.startswith('BEGIN TRANSACTION;')
+      assert batched.rstrip().endswith('COMMIT TRANSACTION;')
+      assert 'CREATE TABLE test;' in batched
+      assert 'CREATE TABLE test2;' in batched
 
       # Verify migration was recorded
       mock_record.assert_called_once()
@@ -165,7 +172,13 @@ class TestExecuteMigration:
 
   @pytest.mark.anyio
   async def test_execute_migration_statement_failure(self, mock_db_client, tmp_path: Path):
-    """Test migration execution with statement failure."""
+    """Test migration execution with statement failure.
+
+    With the bug #13 batched strategy the whole migration lands in a
+    single ``query`` RPC; an error anywhere inside the batch surfaces
+    as a single failure which must be wrapped as
+    ``MigrationExecutionError``.
+    """
     migration = Migration(
       version='20260101_120000',
       description='Test',
@@ -174,22 +187,12 @@ class TestExecuteMigration:
       down=lambda: ['DROP TABLE test;'],
     )
 
-    # Mock query to succeed for BEGIN TRANSACTION then fail on statements
-    call_count = 0
-
-    async def side_effect(query: str, _params: dict | None = None) -> list:
-      nonlocal call_count
-      call_count += 1
-      if 'BEGIN' in query or 'CANCEL' in query:
-        return [{'result': [], 'time': '0ns'}]
-      raise QueryError('Syntax error')
-
-    mock_db_client._client.query = AsyncMock(side_effect=side_effect)
+    mock_db_client._client.query = AsyncMock(side_effect=QueryError('Syntax error'))
 
     with pytest.raises(MigrationExecutionError) as exc_info:
       await execute_migration(mock_db_client, migration, MigrationDirection.UP)
 
-    assert 'Failed to execute statement' in str(exc_info.value)
+    assert 'Failed to execute migration' in str(exc_info.value)
     assert '20260101_120000' in str(exc_info.value)
 
   @pytest.mark.anyio
@@ -658,9 +661,9 @@ class TestExecuteMigrationPlan:
     with patch('surql.migration.executor.record_migration', new=AsyncMock()):
       await execute_migration_plan(mock_db_client, plan)
 
-      # Verify both migrations were executed
-      # 2 migrations x 3 calls each (BEGIN + statement + COMMIT)
-      assert mock_db_client._client.query.call_count == 6
+      # Bug #13: 1 batched RPC per migration (2 migrations -> 2 RPCs),
+      # not one RPC per statement inside each migration.
+      assert mock_db_client._client.query.call_count == 2
 
   @pytest.mark.anyio
   async def test_execute_migration_plan_down(self, mock_db_client, tmp_path: Path):
@@ -687,8 +690,8 @@ class TestExecuteMigrationPlan:
     with patch('surql.migration.executor.remove_migration_record', new=AsyncMock()):
       await execute_migration_plan(mock_db_client, plan)
 
-      # 2 migrations x 3 calls each (BEGIN + statement + COMMIT)
-      assert mock_db_client._client.query.call_count == 6
+      # Bug #13: 1 batched RPC per migration.
+      assert mock_db_client._client.query.call_count == 2
 
   @pytest.mark.anyio
   async def test_execute_migration_plan_empty(self, mock_db_client):


### PR DESCRIPTION
SurrealDB v3 rejects a bare `COMMIT TRANSACTION` sent as a separate RPC. SDK v2.0.0a1 does not expose an interactive `db.begin()` API, so this port uses option (b) from the rs reference: buffer queued statements client-side and flush as `BEGIN TRANSACTION; … ; COMMIT TRANSACTION;` in one `db.query` call.

Scope extended: `src/surql/migration/executor.py` also emitted split-RPC `BEGIN/COMMIT/CANCEL` at lines 117/120/123 — same fix applied there.

Behaviour changes:
- `Transaction.execute` now returns `None`; results become available from `commit()`'s return value.
- Duplicate parameter keys across queued statements raise `TransactionError`.

Closes #13.