### PR TITLE
fix(query): use raw SELECT instead of db.select('table:id') on v3

### DIFF
--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -84,6 +84,45 @@ def _normalize_sdk_value(value: Any) -> Any:
   return value
 
 
+def _extract_select_rows(value: Any) -> list[Any]:
+  """Flatten a SurrealDB query response to a list of result rows.
+
+  The SDK's ``query`` method may return any of these shapes depending
+  on the server version and statement count:
+
+  - ``[{'result': [rows...], 'status': 'OK', ...}, ...]`` -- classic
+    response envelope, one entry per statement in the batch.
+  - ``[rows...]`` -- a bare list of rows (SDK 2.x unwraps single-
+    statement queries).
+  - ``rows...`` -- a scalar or dict (single-record selects on some
+    paths).
+
+  This helper flattens all of those into a list of row dicts.
+
+  Args:
+    value: Raw SDK response
+
+  Returns:
+    List of row dicts (possibly empty)
+  """
+  if value is None:
+    return []
+  if isinstance(value, dict):
+    if 'result' in value:
+      inner = value['result']
+      return inner if isinstance(inner, list) else [inner] if inner is not None else []
+    return [value]
+  if isinstance(value, list):
+    if len(value) == 0:
+      return []
+    if isinstance(value[0], dict) and 'result' in value[0] and 'status' in value[0]:
+      # Statement envelope form; flatten the first statement's rows.
+      inner = value[0].get('result')
+      return inner if isinstance(inner, list) else [inner] if inner is not None else []
+    return list(value)
+  return [value]
+
+
 class DatabaseError(Exception):
   """Base exception for database operations."""
 
@@ -258,6 +297,13 @@ class DatabaseClient:
     element so callers always receive a dict (or ``None``) for single-record
     selects, and a list for table-level selects.
 
+    On SurrealDB v3, passing ``'table:id'`` as a bare string to
+    ``db.select`` is interpreted as a table name containing a colon
+    (and silently returns nothing). When the target matches the
+    record-id pattern we dispatch via raw SurrealQL
+    ``SELECT * FROM type::thing($table, $id)`` so the server treats it
+    as a specific record. Mirrors the TS / rs / go ports.
+
     Args:
       target: Target table or record ID
 
@@ -274,14 +320,18 @@ class DatabaseClient:
     async with self._semaphore:
       try:
         self._log.debug('executing_select', target=target)
+
+        if _is_record_id_target(target):
+          table, id_part = target.split(':', 1)
+          raw = await self._client.query(
+            'SELECT * FROM type::thing($table, $id)',
+            {'table': table, 'id': id_part},
+          )
+          rows = _extract_select_rows(_normalize_sdk_value(raw))
+          return rows[0] if rows else None
+
         result = await self._client.select(target)
-        result = _normalize_sdk_value(result)
-
-        # Unwrap single-record selects: SDK returns a list even for record IDs
-        if _is_record_id_target(target) and isinstance(result, list):
-          return result[0] if result else None
-
-        return result
+        return _normalize_sdk_value(result)
       except Exception as e:
         self._log.error('select_failed', error=str(e), target=target)
         raise QueryError(f'SELECT operation failed: {e}') from e

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -377,10 +377,51 @@ class TestDatabaseClient:
 
   @pytest.mark.anyio
   async def test_select_success(self, mock_db_client: DatabaseClient) -> None:
-    """Test successful SELECT operation."""
+    """Test successful SELECT operation on a bare table target."""
     await mock_db_client.select('user')
 
     mock_db_client._client.select.assert_called_once_with('user')
+
+  @pytest.mark.anyio
+  async def test_select_record_id_uses_type_thing_query(
+    self, mock_db_client: DatabaseClient
+  ) -> None:
+    """Regression (bug #15): `"table:id"` targets must route through
+    `SELECT * FROM type::thing($table, $id)`.
+
+    On SurrealDB v3, passing a bare ``"user:alice"`` string to
+    ``db.select`` is interpreted as a table name containing a colon
+    and returns nothing. The client must detect record-id-shaped
+    targets and dispatch via raw SurrealQL so the server treats them
+    as record ids. TS / rs / go ports all do this.
+    """
+    mock_db_client._client.query = AsyncMock(return_value=[{'id': 'user:alice', 'name': 'Alice'}])
+
+    result = await mock_db_client.select('user:alice')
+
+    # Must NOT go through the SDK's bare string `select` path.
+    mock_db_client._client.select.assert_not_called()
+
+    # Must hit `query` with `type::thing($table, $id)` and bound params.
+    mock_db_client._client.query.assert_called_once()
+    sql, params = mock_db_client._client.query.call_args.args
+    assert 'type::thing($table, $id)' in sql
+    assert params == {'table': 'user', 'id': 'alice'}
+
+    # Single-record unwrap still yields a dict (not a list).
+    assert isinstance(result, dict)
+    assert result['id'] == 'user:alice'
+
+  @pytest.mark.anyio
+  async def test_select_record_id_returns_none_when_missing(
+    self, mock_db_client: DatabaseClient
+  ) -> None:
+    """Missing record yields `None`, not an empty list."""
+    mock_db_client._client.query = AsyncMock(return_value=[])
+
+    result = await mock_db_client.select('user:ghost')
+
+    assert result is None
 
   @pytest.mark.anyio
   async def test_select_not_connected(self, db_config: ConnectionConfig) -> None:

--- a/tests/test_sdk_normalization.py
+++ b/tests/test_sdk_normalization.py
@@ -147,8 +147,13 @@ class TestSelectSingleRecordUnwrap:
 
   @pytest.mark.anyio
   async def test_select_record_id_unwraps_list(self, mock_db_client: DatabaseClient) -> None:
-    """Selecting a record ID unwraps the single-element list to a dict."""
-    mock_db_client._client.select = AsyncMock(return_value=[{'id': 'user:alice', 'name': 'Alice'}])
+    """Selecting a record ID unwraps the single-element list to a dict.
+
+    Bug #15: record-id targets now route through raw
+    ``SELECT * FROM type::thing($table, $id)`` rather than the SDK's
+    bare-string ``select``, so the mock is placed on ``query``.
+    """
+    mock_db_client._client.query = AsyncMock(return_value=[{'id': 'user:alice', 'name': 'Alice'}])
 
     result = await mock_db_client.select('user:alice')
 
@@ -161,7 +166,7 @@ class TestSelectSingleRecordUnwrap:
     self, mock_db_client: DatabaseClient
   ) -> None:
     """Selecting a non-existent record ID returns None."""
-    mock_db_client._client.select = AsyncMock(return_value=[])
+    mock_db_client._client.query = AsyncMock(return_value=[])
 
     result = await mock_db_client.select('user:nonexistent')
 
@@ -169,7 +174,7 @@ class TestSelectSingleRecordUnwrap:
 
   @pytest.mark.anyio
   async def test_select_table_returns_list(self, mock_db_client: DatabaseClient) -> None:
-    """Selecting a table returns the full list."""
+    """Selecting a table returns the full list (still via SDK select())."""
     mock_db_client._client.select = AsyncMock(
       return_value=[
         {'id': 'user:alice', 'name': 'Alice'},
@@ -188,7 +193,7 @@ class TestSelectSingleRecordUnwrap:
   ) -> None:
     """Selecting a record ID normalizes SDK RecordID in the response."""
     sdk_rid = SdkRecordID('user', 'alice')
-    mock_db_client._client.select = AsyncMock(return_value=[{'id': sdk_rid, 'name': 'Alice'}])
+    mock_db_client._client.query = AsyncMock(return_value=[{'id': sdk_rid, 'name': 'Alice'}])
 
     result = await mock_db_client.select('user:alice')
 


### PR DESCRIPTION
On v3, the Python SDK's `db.select("table:id")` is interpreted as a table name. Replace with raw SurrealQL `SELECT * FROM type::thing($table, $id)`. Matches rs + go ports.

Closes #15.