### PR TITLE
fix(migration): add IF NOT EXISTS to DEFINE TABLE _migration_history

### DIFF
--- a/src/surql/migration/history.py
+++ b/src/surql/migration/history.py
@@ -48,15 +48,20 @@ async def create_migration_table(client: DatabaseClient) -> None:
   try:
     log.info('creating_migration_history_table')
 
-    # Define the migration history table
+    # Define the migration history table. `IF NOT EXISTS` makes every
+    # DEFINE idempotent so repeated calls against an already-initialised
+    # SurrealDB v3 database do not fail with "table/field/index already
+    # exists". Matches the rs/go ports.
     statements = [
-      f'DEFINE TABLE {MIGRATION_TABLE_NAME} SCHEMAFULL;',
-      f'DEFINE FIELD version ON TABLE {MIGRATION_TABLE_NAME} TYPE string;',
-      f'DEFINE FIELD description ON TABLE {MIGRATION_TABLE_NAME} TYPE string;',
-      f'DEFINE FIELD applied_at ON TABLE {MIGRATION_TABLE_NAME} TYPE datetime;',
-      f'DEFINE FIELD checksum ON TABLE {MIGRATION_TABLE_NAME} TYPE string;',
-      f'DEFINE FIELD execution_time_ms ON TABLE {MIGRATION_TABLE_NAME} TYPE int;',
-      f'DEFINE INDEX version_idx ON TABLE {MIGRATION_TABLE_NAME} COLUMNS version UNIQUE;',
+      f'DEFINE TABLE IF NOT EXISTS {MIGRATION_TABLE_NAME} SCHEMAFULL;',
+      f'DEFINE FIELD IF NOT EXISTS version ON TABLE {MIGRATION_TABLE_NAME} TYPE string;',
+      f'DEFINE FIELD IF NOT EXISTS description ON TABLE {MIGRATION_TABLE_NAME} TYPE string;',
+      f'DEFINE FIELD IF NOT EXISTS applied_at ON TABLE {MIGRATION_TABLE_NAME} TYPE datetime;',
+      f'DEFINE FIELD IF NOT EXISTS checksum ON TABLE {MIGRATION_TABLE_NAME} TYPE string;',
+      f'DEFINE FIELD IF NOT EXISTS execution_time_ms ON TABLE {MIGRATION_TABLE_NAME} '
+      'TYPE option<int>;',
+      f'DEFINE INDEX IF NOT EXISTS version_idx ON TABLE {MIGRATION_TABLE_NAME} '
+      'COLUMNS version UNIQUE;',
     ]
 
     for statement in statements:

--- a/tests/test_migration_history.py
+++ b/tests/test_migration_history.py
@@ -40,15 +40,34 @@ class TestCreateMigrationTable:
     # Verify table definition
     assert any('DEFINE TABLE' in call and MIGRATION_TABLE_NAME in call for call in calls)
 
-    # Verify field definitions
-    assert any('DEFINE FIELD version' in call for call in calls)
-    assert any('DEFINE FIELD description' in call for call in calls)
-    assert any('DEFINE FIELD applied_at' in call for call in calls)
-    assert any('DEFINE FIELD checksum' in call for call in calls)
-    assert any('DEFINE FIELD execution_time_ms' in call for call in calls)
+    # Verify field definitions (match on trailing field name, not a
+    # fixed substring, so `IF NOT EXISTS` can sit in the middle).
+    assert any(' version ON TABLE' in call for call in calls)
+    assert any(' description ON TABLE' in call for call in calls)
+    assert any(' applied_at ON TABLE' in call for call in calls)
+    assert any(' checksum ON TABLE' in call for call in calls)
+    assert any(' execution_time_ms ON TABLE' in call for call in calls)
 
     # Verify index definition
-    assert any('DEFINE INDEX version_idx' in call and 'UNIQUE' in call for call in calls)
+    assert any('version_idx ON TABLE' in call and 'UNIQUE' in call for call in calls)
+
+  @pytest.mark.anyio
+  async def test_create_migration_table_uses_if_not_exists(self, mock_db_client):
+    """Regression (bug #16): every DEFINE must be ``IF NOT EXISTS``.
+
+    Without it, repeated calls to ``create_migration_table`` on
+    SurrealDB v3 fail with "table already exists" / "field already
+    exists" / "index already exists". ``ensure_migration_table``
+    invokes this helper on basically every migration call, so
+    idempotency is required.
+    """
+    mock_db_client.execute = AsyncMock(return_value=[])
+
+    await create_migration_table(mock_db_client)
+
+    statements = [call[0][0] for call in mock_db_client.execute.call_args_list]
+    for stmt in statements:
+      assert 'IF NOT EXISTS' in stmt, f'DEFINE statement must be idempotent on v3; got {stmt!r}'
 
   @pytest.mark.anyio
   async def test_create_migration_table_query_error(self, mock_db_client):


### PR DESCRIPTION
Repeated `create_migration_table()` on v3 fails with "table already exists". Add `IF NOT EXISTS` so the definition is idempotent. Also bumps `execution_time_ms` from `TYPE int` to `TYPE option<int>` to match the rs port (the field is genuinely optional).

Closes #16.