### PR TITLE
fix(migration): narrow ensure_migration_table except clause

### DIFF
--- a/src/surql/migration/history.py
+++ b/src/surql/migration/history.py
@@ -44,6 +44,28 @@ def _record_id_for(version: str) -> str:
   return ''.join(c if c.isalnum() else '_' for c in version)
 
 
+def _is_table_missing_error(err: Exception) -> bool:
+  """Return True if the given error looks like SurrealDB's
+  'table does not exist' response.
+
+  SurrealDB v2.x treated a missing table as an empty result;
+  v3+ surfaces 'The table X does not exist' (or similar
+  'not found'/'does not exist' wording depending on server
+  version). Case-insensitive substring check mirrors go's
+  ``isTableMissingError``.
+
+  Args:
+    err: The raised exception, typically a ``QueryError``.
+
+  Returns:
+    True when the message looks like a missing-table response; False
+    for permissions/auth/syntax errors, which must propagate.
+  """
+  msg = str(err).lower()
+  return 'does not exist' in msg or 'not found' in msg
+
+
+
 async def create_migration_table(client: DatabaseClient) -> None:
   """Create the migration history table if it doesn't exist.
 
@@ -105,8 +127,14 @@ async def ensure_migration_table(client: DatabaseClient) -> None:
   try:
     # Try to query the table to see if it exists
     await client.execute(f'SELECT * FROM {MIGRATION_TABLE_NAME} LIMIT 1')
-  except QueryError:
-    # Table doesn't exist, create it
+  except QueryError as err:
+    # Narrow the catch: only a table-missing error should trigger
+    # table creation. Permissions/auth/syntax/network errors must
+    # propagate, otherwise we mask the real problem and produce
+    # misleading "table already exists" errors afterwards.
+    # Mirrors go's ``isTableMissingError`` heuristic.
+    if not _is_table_missing_error(err):
+      raise
     await create_migration_table(client)
 
 

--- a/tests/test_migration_history.py
+++ b/tests/test_migration_history.py
@@ -119,6 +119,24 @@ class TestEnsureMigrationTable:
     # Should query first, then create table (multiple DEFINE statements)
     assert mock_db_client.execute.call_count > 1
 
+  @pytest.mark.anyio
+  async def test_ensure_migration_table_propagates_non_missing_errors(self, mock_db_client):
+    """Regression (bug #17): non-table-missing errors must propagate.
+
+    Pre-patch ``ensure_migration_table`` caught any ``QueryError`` and
+    attempted to recreate the table, which masks permissions/auth/
+    syntax/network issues and yields misleading "already exists"
+    errors on the following CREATE.
+    """
+    mock_db_client.execute = AsyncMock(side_effect=QueryError('Insufficient permissions to SELECT'))
+
+    with pytest.raises(QueryError) as exc_info:
+      await ensure_migration_table(mock_db_client)
+
+    assert 'Insufficient permissions' in str(exc_info.value)
+    # Only one call -- the SELECT probe. No CREATE TABLE re-emission.
+    assert mock_db_client.execute.call_count == 1
+
 
 class TestRecordMigration:
   """Test suite for record_migration function."""
@@ -408,14 +426,20 @@ class TestGetAppliedMigrations:
 
   @pytest.mark.anyio
   async def test_get_applied_migrations_query_error(self, mock_db_client):
-    """Test get_applied_migrations handles QueryError from ensure_migration_table."""
+    """Test get_applied_migrations handles QueryError from ensure_migration_table.
+
+    Post bug #17, a non-missing-table QueryError propagates as-is out
+    of ``ensure_migration_table`` and is caught by the outer
+    ``except QueryError`` in ``get_applied_migrations`` -- producing
+    the 'Failed to fetch applied migrations' wrapper rather than the
+    generic 'Unexpected error' branch.
+    """
     mock_db_client.execute = AsyncMock(side_effect=QueryError('Database error'))
 
     with pytest.raises(MigrationHistoryError) as exc_info:
       await get_applied_migrations(mock_db_client)
 
-    # Error is wrapped by ensure_migration_table, then caught as unexpected error
-    assert 'Unexpected error fetching applied migrations' in str(exc_info.value)
+    assert 'Failed to fetch applied migrations' in str(exc_info.value)
 
   @pytest.mark.anyio
   async def test_get_applied_migrations_unexpected_error(self, mock_db_client):
@@ -599,14 +623,17 @@ class TestGetMigrationHistory:
 
   @pytest.mark.anyio
   async def test_get_migration_history_query_error(self, mock_db_client):
-    """Test get_migration_history handles QueryError from ensure_migration_table."""
+    """Test get_migration_history handles QueryError from ensure_migration_table.
+
+    Post bug #17: non-missing QueryErrors propagate into the outer
+    `except QueryError` wrapper rather than the `Exception` fallback.
+    """
     mock_db_client.execute = AsyncMock(side_effect=QueryError('Database error'))
 
     with pytest.raises(MigrationHistoryError) as exc_info:
       await get_migration_history(mock_db_client, '20240101_000000')
 
-    # Error is wrapped by ensure_migration_table, then caught as unexpected error
-    assert 'Unexpected error getting migration history' in str(exc_info.value)
+    assert 'Failed to get migration history' in str(exc_info.value)
 
   @pytest.mark.anyio
   async def test_get_migration_history_unexpected_error(self, mock_db_client):


### PR DESCRIPTION
`ensure_migration_table` previously wrapped the existence probe in a bare `except QueryError`, silently triggering table re-creation on unrelated failures. Narrow to catch only "does not exist" / "not found" substring matches, similar to go's `isTableMissingError`.

Closes #17.