### PR TITLE
fix(v3): type::thing renamed to type::record in SurrealDB v3

### DIFF
--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -301,7 +301,7 @@ class DatabaseClient:
     ``db.select`` is interpreted as a table name containing a colon
     (and silently returns nothing). When the target matches the
     record-id pattern we dispatch via raw SurrealQL
-    ``SELECT * FROM type::thing($table, $id)`` so the server treats it
+    ``SELECT * FROM type::record($table, $id)`` so the server treats it
     as a specific record. Mirrors the TS / rs / go ports.
 
     Args:
@@ -324,7 +324,7 @@ class DatabaseClient:
         if _is_record_id_target(target):
           table, id_part = target.split(':', 1)
           raw = await self._client.query(
-            'SELECT * FROM type::thing($table, $id)',
+            'SELECT * FROM type::record($table, $id)',
             {'table': table, 'id': id_part},
           )
           rows = _extract_select_rows(_normalize_sdk_value(raw))

--- a/src/surql/migration/history.py
+++ b/src/surql/migration/history.py
@@ -32,7 +32,7 @@ def _record_id_for(version: str) -> str:
   """Sanitize a migration version into a safe SurrealDB record id.
 
   SurrealDB record ids must be alphanumeric/underscore (or bracketed).
-  Replace anything else with ``_`` so ``type::thing($table, $id)``
+  Replace anything else with ``_`` so ``type::record($table, $id)``
   accepts the value without extra quoting.
 
   Args:
@@ -198,7 +198,7 @@ async def record_migration(
       params['execution_time_ms'] = execution_time_ms
       set_clauses.append('execution_time_ms = $execution_time_ms')
 
-    statement = f'CREATE type::thing($table, $id) SET {", ".join(set_clauses)};'
+    statement = f'CREATE type::record($table, $id) SET {", ".join(set_clauses)};'
     await client.execute(statement, params)
 
     log.info('migration_recorded', version=version)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -383,11 +383,11 @@ class TestDatabaseClient:
     mock_db_client._client.select.assert_called_once_with('user')
 
   @pytest.mark.anyio
-  async def test_select_record_id_uses_type_thing_query(
+  async def test_select_record_id_uses_type_record_query(
     self, mock_db_client: DatabaseClient
   ) -> None:
     """Regression (bug #15): `"table:id"` targets must route through
-    `SELECT * FROM type::thing($table, $id)`.
+    `SELECT * FROM type::record($table, $id)`.
 
     On SurrealDB v3, passing a bare ``"user:alice"`` string to
     ``db.select`` is interpreted as a table name containing a colon
@@ -402,10 +402,10 @@ class TestDatabaseClient:
     # Must NOT go through the SDK's bare string `select` path.
     mock_db_client._client.select.assert_not_called()
 
-    # Must hit `query` with `type::thing($table, $id)` and bound params.
+    # Must hit `query` with `type::record($table, $id)` and bound params.
     mock_db_client._client.query.assert_called_once()
     sql, params = mock_db_client._client.query.call_args.args
-    assert 'type::thing($table, $id)' in sql
+    assert 'type::record($table, $id)' in sql
     assert params == {'table': 'user', 'id': 'alice'}
 
     # Single-record unwrap still yields a dict (not a list).

--- a/tests/test_migration_history.py
+++ b/tests/test_migration_history.py
@@ -162,7 +162,7 @@ class TestRecordMigration:
     # Last execute call is the CREATE ... SET with <datetime> cast.
     assert mock_db_client.execute.call_count >= 1
     statement, params = mock_db_client.execute.call_args[0]
-    assert 'CREATE type::thing($table, $id)' in statement
+    assert 'CREATE type::record($table, $id)' in statement
     assert '<datetime> $applied_at' in statement
     assert params['table'] == MIGRATION_TABLE_NAME
     assert params['version'] == '20240101_000000'
@@ -212,7 +212,7 @@ class TestRecordMigration:
     )
 
     _, params = mock_db_client.execute.call_args[0]
-    # Dashes, colons must become underscores so `type::thing($table, $id)`
+    # Dashes, colons must become underscores so `type::record($table, $id)`
     # accepts the value without bracket quoting.
     assert params['id'] == '2026_01_02T12_00_00'
 

--- a/tests/test_sdk_normalization.py
+++ b/tests/test_sdk_normalization.py
@@ -150,7 +150,7 @@ class TestSelectSingleRecordUnwrap:
     """Selecting a record ID unwraps the single-element list to a dict.
 
     Bug #15: record-id targets now route through raw
-    ``SELECT * FROM type::thing($table, $id)`` rather than the SDK's
+    ``SELECT * FROM type::record($table, $id)`` rather than the SDK's
     bare-string ``select``, so the mock is placed on ``query``.
     """
     mock_db_client._client.query = AsyncMock(return_value=[{'id': 'user:alice', 'name': 'Alice'}])


### PR DESCRIPTION
## Summary

SurrealDB v3 replaced `type::thing(table, id)` with `type::record(table, id)`. Caught by the new v3 integration CI (PR #27) running against surrealdb/surrealdb:v3.0.5:

```
Parse error: Invalid function/constant path, did you maybe mean `type::record`
 --> [1:8]
1 | CREATE type::thing($table, $id) SET ...
```

## Scope

- `src/surql/migration/history.py:201` — CREATE in `record_migration`
- `src/surql/connection/client.py:327` — SELECT in `get_record`
- doc-comment and test references

## Test plan

- [x] `uv run ruff check src tests` clean
- [x] `uv run mypy src` clean
- [x] `uv run pytest tests/test_connection.py tests/test_migration_history.py tests/test_sdk_normalization.py` — 257 passed

Closes #28.