### PR TITLE
fix(v3): emit v3-valid query forms in batch + graph + GraphQuery

### DIFF
--- a/src/surql/query/batch.py
+++ b/src/surql/query/batch.py
@@ -58,6 +58,23 @@ def _format_items_array(items: list[dict[str, Any]]) -> str:
   return '[\n  ' + ',\n  '.join(item_strs) + '\n]'
 
 
+def _build_upsert_target(_table: str, raw: str) -> str:
+  """Return an UPSERT target clause valid on SurrealDB v3.
+
+  Callers pass either a table name or a record id like ``user:alice``.
+  Table names are validated as identifiers; record ids are emitted
+  verbatim (SurrealDB parses ``table:id`` natively as a record target).
+  The ``_table`` arg is reserved for callers that might want a fallback
+  to a table-level UPSERT in a future revision — today the function
+  returns ``raw`` verbatim when it contains a colon, and validates it
+  otherwise.
+  """
+  if ':' in raw:
+    return raw
+  _validate_identifier(raw, 'table name')
+  return raw
+
+
 async def upsert_many(
   client: DatabaseClient | None,
   table: str,
@@ -122,20 +139,29 @@ async def upsert_many(
     else:
       item_dicts.append(item)
 
-  # Build UPSERT statement
-  items_array = _format_items_array(item_dicts)
+  # SurrealDB v3 rejects `UPSERT INTO <table> [ {...}, {...} ]` with a
+  # parse error. Emit one `UPSERT <target> CONTENT $data` statement per
+  # record and batch them into a single multi-statement query. Matches
+  # the surql-rs / surql-go ports. See Oneiriq/surql-py#32.
+  statements: list[str] = []
+  params: dict[str, Any] = {}
+  for idx, data in enumerate(item_dicts):
+    payload = {k: v for k, v in data.items() if k != 'id'}
+    target = data.get('id') or table
+    target_clean = _build_upsert_target(table, target)
+    bind = f'item_{idx}'
+    params[bind] = payload
+    if conflict_fields:
+      conditions = ' AND '.join(f'{field} = ${bind}.{field}' for field in conflict_fields)
+      statements.append(f'UPSERT {target_clean} CONTENT ${bind} WHERE {conditions};')
+    else:
+      statements.append(f'UPSERT {target_clean} CONTENT ${bind};')
 
-  # Build the query
-  if conflict_fields:
-    # Use WHERE clause with conflict fields for matching
-    conditions = ' AND '.join(f'{field} = $item.{field}' for field in conflict_fields)
-    query = f'UPSERT INTO {table} {items_array} WHERE {conditions};'
-  else:
-    query = f'UPSERT INTO {table} {items_array};'
+  query = '\n'.join(statements)
 
   logger.debug('upsert_many_query', query=query)
 
-  result = await db.execute(query)
+  result = await db.execute(query, params)
 
   # Extract results from execute response
   records: list[dict[str, Any]] = []
@@ -445,14 +471,22 @@ def build_upsert_query(
     for field in conflict_fields:
       _validate_identifier(field, 'conflict field name')
 
-  # Field names in items are validated by _format_items_array
-  items_array = _format_items_array(items)
+  # SurrealDB v3 rejects `UPSERT INTO <table> [ ... ]`. Emit per-record
+  # statements matching the surql-rs / surql-go ports. Non-id items are
+  # targeted by table (UPSERT will pick the first match or insert).
+  statements: list[str] = []
+  for data in items:
+    payload = {k: v for k, v in data.items() if k != 'id'}
+    target = data.get('id') or table
+    target_clean = _build_upsert_target(table, target)
+    payload_literal = _format_items_array([payload]).strip('[] \n\t,')
+    if conflict_fields:
+      conditions = ' AND '.join(f'{field} = $item.{field}' for field in conflict_fields)
+      statements.append(f'UPSERT {target_clean} CONTENT {payload_literal} WHERE {conditions};')
+    else:
+      statements.append(f'UPSERT {target_clean} CONTENT {payload_literal};')
 
-  if conflict_fields:
-    conditions = ' AND '.join(f'{field} = $item.{field}' for field in conflict_fields)
-    return f'UPSERT INTO {table} {items_array} WHERE {conditions};'
-
-  return f'UPSERT INTO {table} {items_array};'
+  return '\n'.join(statements)
 
 
 # Functional helper for generating batch relate SQL

--- a/src/surql/query/graph.py
+++ b/src/surql/query/graph.py
@@ -65,11 +65,13 @@ async def find_mutual_connections[T: BaseModel](
 
   logger.info('finding_mutual_connections', record=record_str, edge=edge)
 
-  # Query: Find records that I follow AND that follow me back
-  # This uses set intersection via SurrealDB's graph traversal
+  # Query: Find records that I follow AND that follow me back.
+  # SurrealDB v3 rejects `FROM <-edge<-record` (no left anchor). Use
+  # `FROM record<-edge` form, which is v2- and v3-valid. See
+  # Oneiriq/surql-py#33.
   sql = f"""
     SELECT * FROM {record_str}->{edge}
-    WHERE id IN (SELECT VALUE id FROM <-{edge}<-{record_str})
+    WHERE id IN (SELECT VALUE id FROM {record_str}<-{edge})
   """
 
   db = client or get_db()
@@ -129,12 +131,14 @@ async def find_shortest_path(
     result = await db.execute(sql)
     return _extract_graph_result(result)
 
-  # Iterative deepening search
+  # Iterative deepening search.
+  # SurrealDB v3 rejects the v2 `->edge{depth}->` suffix form
+  # ("Parse error: trailing arrow has no target"). Use the grouped
+  # `(->edge->?){depth}` form with a `?` wildcard target — v3-valid and
+  # v2-compatible. See Oneiriq/surql-py#34.
   for depth in range(1, max_depth + 1):
-    # Build path query for current depth
-    # Use depth notation: ->edge{depth}->
     sql = f"""
-      SELECT * FROM {from_str}->{edge}{depth}->
+      SELECT * FROM {from_str}(->{edge}->?){{{depth}}}
       WHERE id = {to_str}
       LIMIT 1
     """
@@ -192,12 +196,13 @@ async def _reconstruct_path(
 
   current = from_str
   for _ in range(depth):
-    # Find next node in path towards target
+    # Find next node in path towards target. v3-safe incoming form:
+    # `{to_str}(<-edge<-?){depth}` instead of `<-edge{depth}<-{to_str}`.
     sql = f"""
       SELECT * FROM {current}->{edge}
       WHERE id = {to_str} OR id IN (
         SELECT VALUE id FROM {current}->{edge}
-        WHERE id IN (SELECT VALUE id FROM <-{edge}{depth}<-{to_str})
+        WHERE id IN (SELECT VALUE id FROM {to_str}(<-{edge}<-?){{{depth}}})
       )
       LIMIT 1
     """
@@ -271,8 +276,12 @@ async def get_neighbors(
 
   db = client or get_db()
 
+  # SurrealDB v3 rejects the v2 `{arrow}{edge}{d}` suffix form
+  # ("Parse error: trailing arrow has no target"). Use the grouped
+  # ``({arrow}{edge}{arrow}?){d}`` wildcard form which v3 accepts and
+  # is v2-compatible. See Oneiriq/surql-py#34.
   for d in range(1, depth + 1):
-    sql = f'SELECT * FROM {record_str}{arrow}{edge}{d}'
+    sql = f'SELECT * FROM {record_str}({arrow}{edge}{arrow}?){{{d}}}'
     result = await db.execute(sql)
     data = _extract_graph_result(result)
 
@@ -328,8 +337,8 @@ async def compute_degree(
   if out_data and isinstance(out_data[0], dict):
     out_degree = out_data[0].get('count', 0)
 
-  # Count incoming edges
-  in_sql = f'SELECT count() FROM <-{edge}<-{record_str} GROUP ALL'
+  # Count incoming edges. v3-safe form anchors the record on the left.
+  in_sql = f'SELECT count() FROM {record_str}<-{edge} GROUP ALL'
   in_result = await db.execute(in_sql)
   in_data = _extract_graph_result(in_result)
   in_degree = 0
@@ -615,7 +624,9 @@ async def get_incoming_edges[T: BaseModel](
 
   logger.info('fetching_incoming_edges', record=record_str, edge_table=edge_table)
 
-  sql = f'SELECT * FROM <-{edge_table}<-{record_str}'
+  # v3-safe form: anchor record on the left (`record<-edge`), not the
+  # v2 `<-edge<-record` which v3 rejects. See Oneiriq/surql-py#33.
+  sql = f'SELECT * FROM {record_str}<-{edge_table}'
 
   db = client or get_db()
   result = await db.execute(sql)
@@ -722,7 +733,8 @@ async def count_related(
   if direction == 'out':
     sql = f'SELECT count() FROM {record_str}->{edge_table}'
   elif direction == 'in':
-    sql = f'SELECT count() FROM <-{edge_table}<-{record_str}'
+    # v3-safe form anchors the record on the left.
+    sql = f'SELECT count() FROM {record_str}<-{edge_table}'
   else:
     raise ValueError(f'Invalid direction: {direction}. Must be "out" or "in"')
 
@@ -773,13 +785,13 @@ async def shortest_path(
 
   logger.info('finding_shortest_path', from_record=from_str, to_record=to_str, max_depth=max_depth)
 
-  # Use iterative depth-first search
-  # This is a simplified implementation
+  # Iterative deepening. v3 rejects `->edge{d}->` trailing-arrow; use
+  # the grouped `(->edge->?){d}` form. See Oneiriq/surql-py#34.
   for depth in range(1, max_depth + 1):
     sql = f"""
-    SELECT * FROM {from_str}
-    ->{edge_table}{depth}->
+    SELECT * FROM {from_str}(->{edge_table}->?){{{depth}}}
     WHERE id = {to_str}
+    LIMIT 1
     """
 
     db = client or get_db()

--- a/src/surql/query/graph.py
+++ b/src/surql/query/graph.py
@@ -132,13 +132,15 @@ async def find_shortest_path(
     return _extract_graph_result(result)
 
   # Iterative deepening search.
-  # SurrealDB v3 rejects the v2 `->edge{depth}->` suffix form
-  # ("Parse error: trailing arrow has no target"). Use the grouped
-  # `(->edge->?){depth}` form with a `?` wildcard target — v3-valid and
-  # v2-compatible. See Oneiriq/surql-py#34.
+  # SurrealDB v3 rejects both the v2 `->edge{depth}->` suffix form AND
+  # the grouped `(->edge->?){depth}` repetition form (the latter parses
+  # until `{` which v3 flags as `Unexpected token, expected Eof`).
+  # The v3-safe path — matches the surql-go port — is to unroll the
+  # depth into N literal `->edge->?` segments. See Oneiriq/surql-py#34.
   for depth in range(1, max_depth + 1):
+    hops = ''.join(f'->{edge}->?' for _ in range(depth))
     sql = f"""
-      SELECT * FROM {from_str}(->{edge}->?){{{depth}}}
+      SELECT * FROM {from_str}{hops}
       WHERE id = {to_str}
       LIMIT 1
     """
@@ -196,13 +198,15 @@ async def _reconstruct_path(
 
   current = from_str
   for _ in range(depth):
-    # Find next node in path towards target. v3-safe incoming form:
-    # `{to_str}(<-edge<-?){depth}` instead of `<-edge{depth}<-{to_str}`.
+    # Find next node in path towards target. v3 rejects both the v2
+    # suffix and the grouped-repetition forms; unroll to literal
+    # `<-edge<-?` hops. See Oneiriq/surql-py#34.
+    in_hops = ''.join(f'<-{edge}<-?' for _ in range(depth))
     sql = f"""
       SELECT * FROM {current}->{edge}
       WHERE id = {to_str} OR id IN (
         SELECT VALUE id FROM {current}->{edge}
-        WHERE id IN (SELECT VALUE id FROM {to_str}(<-{edge}<-?){{{depth}}})
+        WHERE id IN (SELECT VALUE id FROM {to_str}{in_hops})
       )
       LIMIT 1
     """
@@ -276,12 +280,13 @@ async def get_neighbors(
 
   db = client or get_db()
 
-  # SurrealDB v3 rejects the v2 `{arrow}{edge}{d}` suffix form
-  # ("Parse error: trailing arrow has no target"). Use the grouped
-  # ``({arrow}{edge}{arrow}?){d}`` wildcard form which v3 accepts and
-  # is v2-compatible. See Oneiriq/surql-py#34.
+  # SurrealDB v3 rejects both the v2 `{arrow}{edge}{d}` suffix form and
+  # the grouped `({arrow}edge{arrow}?){d}` repetition. Unroll to N
+  # literal `{arrow}edge{arrow}?` hops — matches surql-go. See
+  # Oneiriq/surql-py#34.
   for d in range(1, depth + 1):
-    sql = f'SELECT * FROM {record_str}({arrow}{edge}{arrow}?){{{d}}}'
+    hops = ''.join(f'{arrow}{edge}{arrow}?' for _ in range(d))
+    sql = f'SELECT * FROM {record_str}{hops}'
     result = await db.execute(sql)
     data = _extract_graph_result(result)
 
@@ -785,11 +790,13 @@ async def shortest_path(
 
   logger.info('finding_shortest_path', from_record=from_str, to_record=to_str, max_depth=max_depth)
 
-  # Iterative deepening. v3 rejects `->edge{d}->` trailing-arrow; use
-  # the grouped `(->edge->?){d}` form. See Oneiriq/surql-py#34.
+  # Iterative deepening. v3 rejects both the v2 trailing-arrow form and
+  # the grouped `{depth}` repetition; unroll to N literal `->edge->?`
+  # hops. See Oneiriq/surql-py#34.
   for depth in range(1, max_depth + 1):
+    hops = ''.join(f'->{edge_table}->?' for _ in range(depth))
     sql = f"""
-    SELECT * FROM {from_str}(->{edge_table}->?){{{depth}}}
+    SELECT * FROM {from_str}{hops}
     WHERE id = {to_str}
     LIMIT 1
     """

--- a/src/surql/query/graph_query.py
+++ b/src/surql/query/graph_query.py
@@ -137,8 +137,12 @@ class GraphQuery[T: BaseModel]:
       >>> GraphQuery("user:alice").out("follows")  # Direct follows
       >>> GraphQuery("user:alice").out("follows", depth=2)  # 2 hops
     """
-    depth_str = str(depth) if depth is not None else ''
-    self._path.append(f'->{edge}{depth_str}')
+    # SurrealDB v3 rejects the v2 `->edge{depth}` suffix form. When a
+    # depth is supplied, emit the grouped `(->edge->?){depth}` form
+    # which is v3-valid and v2-compatible. See Oneiriq/surql-py#34.
+    self._path.append(
+      f'(->{edge}->?){{{depth}}}' if depth is not None else f'->{edge}'
+    )
     return self
 
   def in_(self, edge: str, depth: int | None = None) -> GraphQuery[T]:
@@ -155,8 +159,9 @@ class GraphQuery[T: BaseModel]:
       >>> GraphQuery("user:alice").in_("follows")  # Who follows alice
       >>> GraphQuery("user:alice").in_("follows", depth=2)  # 2 hops back
     """
-    depth_str = str(depth) if depth is not None else ''
-    self._path.append(f'<-{edge}{depth_str}')
+    self._path.append(
+      f'(<-{edge}<-?){{{depth}}}' if depth is not None else f'<-{edge}'
+    )
     return self
 
   def both(self, edge: str, depth: int | None = None) -> GraphQuery[T]:
@@ -172,8 +177,9 @@ class GraphQuery[T: BaseModel]:
     Examples:
       >>> GraphQuery("user:alice").both("knows")  # All connections
     """
-    depth_str = str(depth) if depth is not None else ''
-    self._path.append(f'<->{edge}{depth_str}')
+    self._path.append(
+      f'(<->{edge}<->?){{{depth}}}' if depth is not None else f'<->{edge}'
+    )
     return self
 
   def to(self, table: str) -> GraphQuery[T]:

--- a/src/surql/query/graph_query.py
+++ b/src/surql/query/graph_query.py
@@ -137,11 +137,12 @@ class GraphQuery[T: BaseModel]:
       >>> GraphQuery("user:alice").out("follows")  # Direct follows
       >>> GraphQuery("user:alice").out("follows", depth=2)  # 2 hops
     """
-    # SurrealDB v3 rejects the v2 `->edge{depth}` suffix form. When a
-    # depth is supplied, emit the grouped `(->edge->?){depth}` form
-    # which is v3-valid and v2-compatible. See Oneiriq/surql-py#34.
+    # SurrealDB v3 rejects both the v2 `->edge{depth}` suffix form and
+    # the grouped `(->edge->?){depth}` repetition. Unroll to N literal
+    # `->edge->?` hops — v3-valid and matches the surql-go port. See
+    # Oneiriq/surql-py#34.
     self._path.append(
-      f'(->{edge}->?){{{depth}}}' if depth is not None else f'->{edge}'
+      ''.join(f'->{edge}->?' for _ in range(depth)) if depth is not None else f'->{edge}'
     )
     return self
 
@@ -160,7 +161,7 @@ class GraphQuery[T: BaseModel]:
       >>> GraphQuery("user:alice").in_("follows", depth=2)  # 2 hops back
     """
     self._path.append(
-      f'(<-{edge}<-?){{{depth}}}' if depth is not None else f'<-{edge}'
+      ''.join(f'<-{edge}<-?' for _ in range(depth)) if depth is not None else f'<-{edge}'
     )
     return self
 
@@ -178,7 +179,7 @@ class GraphQuery[T: BaseModel]:
       >>> GraphQuery("user:alice").both("knows")  # All connections
     """
     self._path.append(
-      f'(<->{edge}<->?){{{depth}}}' if depth is not None else f'<->{edge}'
+      ''.join(f'<->{edge}<->?' for _ in range(depth)) if depth is not None else f'<->{edge}'
     )
     return self
 

--- a/tests/integration/test_v3_happy_path.py
+++ b/tests/integration/test_v3_happy_path.py
@@ -256,3 +256,88 @@ async def test_migration_history_table_name_matches(
   result = await integration_client.execute(f'SELECT * FROM {MIGRATION_TABLE_NAME} LIMIT 1')
   # Result type depends on SDK shape, but the call must not raise.
   assert result is not None or result == [] or result == {}
+
+
+# ---------------------------------------------------------------------------
+# Bug #32: UPSERT INTO [...] array form rejected by v3
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertManyV3:
+  """Bug #32: `upsert_many` must emit per-record `UPSERT id CONTENT`."""
+
+  @pytest.mark.anyio
+  async def test_upsert_many_round_trips_on_v3(
+    self, integration_client: DatabaseClient
+  ) -> None:
+    """Two records upserted; readback returns both."""
+    from surql.query.batch import upsert_many
+
+    await integration_client.execute('DEFINE TABLE person SCHEMALESS;')
+    items = [
+      {'id': 'person:alice', 'name': 'Alice', 'age': 30},
+      {'id': 'person:bob', 'name': 'Bob', 'age': 25},
+    ]
+    await upsert_many(integration_client, 'person', items)
+
+    rows = await integration_client.execute('SELECT * FROM person ORDER BY name')
+    # Envelope shape varies by SDK; unwrap either `[row, ...]` or
+    # `[{result:[row, ...]}]`.
+    if isinstance(rows, list) and rows and isinstance(rows[0], dict) and 'result' in rows[0]:
+      rows = rows[0]['result']
+    assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bug #33: `FROM <-edge<-record` form rejected by v3
+# ---------------------------------------------------------------------------
+
+
+class TestIncomingEdgesV3:
+  """Bug #33: incoming-edge queries must anchor the record on the left."""
+
+  @pytest.mark.anyio
+  async def test_get_incoming_edges_on_v3(
+    self, integration_client: DatabaseClient
+  ) -> None:
+    """A `follow` edge from alice to bob; `get_incoming_edges(bob, 'follow')` returns one row."""
+    from surql.query.graph import get_incoming_edges
+
+    await integration_client.execute('DEFINE TABLE user SCHEMALESS;')
+    await integration_client.execute('DEFINE TABLE follow TYPE RELATION SCHEMALESS;')
+    await integration_client.execute("CREATE user:alice SET name = 'Alice'")
+    await integration_client.execute("CREATE user:bob SET name = 'Bob'")
+    await integration_client.execute('RELATE user:alice->follow->user:bob')
+
+    edges = await get_incoming_edges('user:bob', 'follow', client=integration_client)
+    assert len(edges) == 1
+
+
+# ---------------------------------------------------------------------------
+# Bug #34: `->edge{depth}->` trailing-arrow form rejected by v3
+# ---------------------------------------------------------------------------
+
+
+class TestShortestPathV3:
+  """Bug #34: `shortest_path` must emit the grouped `(->edge->?){d}` form."""
+
+  @pytest.mark.anyio
+  async def test_shortest_path_on_v3(self, integration_client: DatabaseClient) -> None:
+    """Alice -> Bob -> Charlie; shortest_path finds a 2-hop path."""
+    from surql.query.graph import find_shortest_path
+
+    await integration_client.execute('DEFINE TABLE user SCHEMALESS;')
+    await integration_client.execute('DEFINE TABLE follows TYPE RELATION SCHEMALESS;')
+    await integration_client.execute("CREATE user:alice SET name = 'Alice'")
+    await integration_client.execute("CREATE user:bob SET name = 'Bob'")
+    await integration_client.execute("CREATE user:charlie SET name = 'Charlie'")
+    await integration_client.execute('RELATE user:alice->follows->user:bob')
+    await integration_client.execute('RELATE user:bob->follows->user:charlie')
+
+    # The helper returns the reconstructed path, but here we only need
+    # to prove the server accepts the emitted SurrealQL (v2 trailing
+    # arrow would parse-error before returning).
+    path = await find_shortest_path(
+      'user:alice', 'user:charlie', 'follows', max_depth=3, client=integration_client
+    )
+    assert isinstance(path, list)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -93,11 +93,14 @@ class TestUpsertMany:
     assert len(results) == 2
     mock_db_client.execute.assert_called_once()
 
-    # Verify Pydantic models were serialized in the query
-    query = mock_db_client.execute.call_args[0][0]
-    assert 'Alice' in query
-    assert 'alice@example.com' in query
-    assert 'Bob' in query
+    # After the v3 refactor (Oneiriq/surql-py#32) payloads flow through
+    # the params dict, not the inlined SQL string. Verify both paths.
+    query, params = mock_db_client.execute.call_args[0]
+    assert 'UPSERT' in query and 'CONTENT' in query
+    payloads = [params[k] for k in sorted(params) if k.startswith('item_')]
+    assert any(p.get('name') == 'Alice' for p in payloads)
+    assert any(p.get('email') == 'alice@example.com' for p in payloads)
+    assert any(p.get('name') == 'Bob' for p in payloads)
 
   @pytest.mark.anyio
   async def test_upsert_many_empty_list(self, mock_db_client: DatabaseClient) -> None:
@@ -119,11 +122,13 @@ class TestUpsertMany:
     items = [{'email': 'alice@example.com', 'name': 'Alice'}]
     await upsert_many(mock_db_client, 'users', items, conflict_fields=['email'])
 
-    # Verify the query contains WHERE clause with conflict fields
+    # After the v3 refactor each record is upserted individually; the
+    # conflict WHERE clause still appears on each emitted statement but
+    # it references the per-record bind `$item_<idx>.<field>`.
     call_args = mock_db_client.execute.call_args
     query = call_args[0][0]
     assert 'WHERE' in query
-    assert 'email = $item.email' in query
+    assert 'email = $item_0.email' in query
 
   @pytest.mark.anyio
   async def test_upsert_many_with_context_client(self, mock_db_client: DatabaseClient) -> None:
@@ -162,11 +167,12 @@ class TestUpsertMany:
 
     assert len(results) == 1
 
-    # Verify nested data structures are in the query
-    query = mock_db_client.execute.call_args[0][0]
-    assert 'metadata' in query
-    assert 'admin' in query
-    assert 'tags' in query
+    # After the v3 refactor, nested structures flow through the params
+    # dict rather than being inlined. Check the bound payload instead.
+    _, params = mock_db_client.execute.call_args[0]
+    payload = params['item_0']
+    assert payload['metadata']['role'] == 'admin'
+    assert payload['metadata']['tags'] == ['active']
 
   @pytest.mark.anyio
   async def test_upsert_many_handles_empty_result(self, mock_db_client: DatabaseClient) -> None:
@@ -518,13 +524,21 @@ class TestBuildUpsertQuery:
   """Test suite for build_upsert_query function."""
 
   def test_build_upsert_query_basic(self) -> None:
-    """Test building basic upsert query."""
+    """Test building basic upsert query.
+
+    Post Oneiriq/surql-py#32 the builder emits one ``UPSERT <target>
+    CONTENT {...}`` per record rather than the v2 ``UPSERT INTO table
+    [...]`` array form (rejected by v3).
+    """
     items = [{'id': 'user:1', 'name': 'Alice'}]
     query = build_upsert_query('users', items)
 
-    assert 'UPSERT INTO users' in query
-    assert 'user:1' in query
+    assert query.startswith('UPSERT user:1 CONTENT')
     assert 'Alice' in query
+    # ``id`` should be stripped from the per-record CONTENT payload:
+    # v3 rejects a redundant ``id`` field when targeting a specific
+    # record.
+    assert "id:" not in query.replace('user:1', '')
 
   def test_build_upsert_query_multiple_items(self) -> None:
     """Test building upsert query with multiple items."""
@@ -534,7 +548,8 @@ class TestBuildUpsertQuery:
     ]
     query = build_upsert_query('users', items)
 
-    assert 'UPSERT INTO users' in query
+    assert 'UPSERT user:1 CONTENT' in query
+    assert 'UPSERT user:2 CONTENT' in query
     assert 'Alice' in query
     assert 'Bob' in query
 

--- a/tests/test_query_graph.py
+++ b/tests/test_query_graph.py
@@ -812,13 +812,16 @@ class TestGraphQueryTraversalMethods:
   def test_out_with_depth(self):
     """Test out() method with specific depth.
 
-    Post Oneiriq/surql-py#34 a depth suffix emits the grouped
-    ``(->edge->?){depth}`` form rather than the v2-only ``->edge{depth}``
-    trailing-arrow form (rejected by SurrealDB v3).
+    Post Oneiriq/surql-py#34 a depth suffix unrolls into N literal
+    ``->edge->?`` hops rather than the v2-only ``->edge{depth}``
+    trailing-arrow form (rejected by SurrealDB v3). The grouped
+    ``(->edge->?){depth}`` repetition form v3 also rejects, which
+    caught out a first-pass fix — the final v3-safe emission is
+    unrolled.
     """
     query = GraphQuery('user:alice').out('follows', depth=2)
 
-    assert '(->follows->?){2}' in query._path
+    assert '->follows->?->follows->?' in query._path
 
   def test_in_without_depth(self):
     """Test in_() method without specifying depth."""
@@ -830,7 +833,7 @@ class TestGraphQueryTraversalMethods:
     """Test in_() method with specific depth."""
     query = GraphQuery('user:alice').in_('follows', depth=3)
 
-    assert '(<-follows<-?){3}' in query._path
+    assert '<-follows<-?<-follows<-?<-follows<-?' in query._path
 
   def test_both_without_depth(self):
     """Test both() method without specifying depth."""
@@ -842,7 +845,7 @@ class TestGraphQueryTraversalMethods:
     """Test both() method with specific depth."""
     query = GraphQuery('user:alice').both('knows', depth=2)
 
-    assert '(<->knows<->?){2}' in query._path
+    assert '<->knows<->?<->knows<->?' in query._path
 
   def test_method_chaining_traversals(self):
     """Test chaining multiple traversal methods."""
@@ -951,7 +954,7 @@ class TestGraphQueryBuild:
     """Test build() generates correct SurrealQL with depth specifier."""
     query = GraphQuery('user:alice').out('follows', depth=2).build()
 
-    assert query == 'SELECT * FROM user:alice(->follows->?){2}'
+    assert query == 'SELECT * FROM user:alice->follows->?->follows->?'
 
   def test_build_with_target_table(self):
     """Test build() generates correct SurrealQL with target table."""
@@ -1354,7 +1357,7 @@ class TestGetNeighbors:
 
     assert len(neighbors) == 2
     call_args = mock_db_client.execute.call_args[0][0]
-    assert '(->follows->?){1}' in call_args
+    assert '->follows->?' in call_args
 
   @pytest.mark.anyio
   async def test_get_neighbors_direction_in(self, mock_db_client):
@@ -1369,7 +1372,7 @@ class TestGetNeighbors:
 
     assert len(neighbors) == 1
     call_args = mock_db_client.execute.call_args[0][0]
-    assert '(<-follows<-?){1}' in call_args
+    assert '<-follows<-?' in call_args
 
   @pytest.mark.anyio
   async def test_get_neighbors_direction_both(self, mock_db_client):
@@ -1391,7 +1394,7 @@ class TestGetNeighbors:
 
     assert len(neighbors) == 2
     call_args = mock_db_client.execute.call_args[0][0]
-    assert '(<->follows<->?){1}' in call_args
+    assert '<->follows<->?' in call_args
 
   @pytest.mark.anyio
   async def test_get_neighbors_multiple_depths(self, mock_db_client):

--- a/tests/test_query_graph.py
+++ b/tests/test_query_graph.py
@@ -810,10 +810,15 @@ class TestGraphQueryTraversalMethods:
     assert '->follows' in query._path
 
   def test_out_with_depth(self):
-    """Test out() method with specific depth."""
+    """Test out() method with specific depth.
+
+    Post Oneiriq/surql-py#34 a depth suffix emits the grouped
+    ``(->edge->?){depth}`` form rather than the v2-only ``->edge{depth}``
+    trailing-arrow form (rejected by SurrealDB v3).
+    """
     query = GraphQuery('user:alice').out('follows', depth=2)
 
-    assert '->follows2' in query._path
+    assert '(->follows->?){2}' in query._path
 
   def test_in_without_depth(self):
     """Test in_() method without specifying depth."""
@@ -825,7 +830,7 @@ class TestGraphQueryTraversalMethods:
     """Test in_() method with specific depth."""
     query = GraphQuery('user:alice').in_('follows', depth=3)
 
-    assert '<-follows3' in query._path
+    assert '(<-follows<-?){3}' in query._path
 
   def test_both_without_depth(self):
     """Test both() method without specifying depth."""
@@ -837,7 +842,7 @@ class TestGraphQueryTraversalMethods:
     """Test both() method with specific depth."""
     query = GraphQuery('user:alice').both('knows', depth=2)
 
-    assert '<->knows2' in query._path
+    assert '(<->knows<->?){2}' in query._path
 
   def test_method_chaining_traversals(self):
     """Test chaining multiple traversal methods."""
@@ -946,7 +951,7 @@ class TestGraphQueryBuild:
     """Test build() generates correct SurrealQL with depth specifier."""
     query = GraphQuery('user:alice').out('follows', depth=2).build()
 
-    assert query == 'SELECT * FROM user:alice->follows2'
+    assert query == 'SELECT * FROM user:alice(->follows->?){2}'
 
   def test_build_with_target_table(self):
     """Test build() generates correct SurrealQL with target table."""
@@ -1349,7 +1354,7 @@ class TestGetNeighbors:
 
     assert len(neighbors) == 2
     call_args = mock_db_client.execute.call_args[0][0]
-    assert '->follows1' in call_args
+    assert '(->follows->?){1}' in call_args
 
   @pytest.mark.anyio
   async def test_get_neighbors_direction_in(self, mock_db_client):
@@ -1364,7 +1369,7 @@ class TestGetNeighbors:
 
     assert len(neighbors) == 1
     call_args = mock_db_client.execute.call_args[0][0]
-    assert '<-follows1' in call_args
+    assert '(<-follows<-?){1}' in call_args
 
   @pytest.mark.anyio
   async def test_get_neighbors_direction_both(self, mock_db_client):
@@ -1386,7 +1391,7 @@ class TestGetNeighbors:
 
     assert len(neighbors) == 2
     call_args = mock_db_client.execute.call_args[0][0]
-    assert '<->follows1' in call_args
+    assert '(<->follows<->?){1}' in call_args
 
   @pytest.mark.anyio
   async def test_get_neighbors_multiple_depths(self, mock_db_client):


### PR DESCRIPTION
## Summary

Fixes three v2-era SurrealQL forms that SurrealDB v3 rejects. All three were caught porting `batch` / `graph` / `graph_query` to surql-rs and surql-go; the v3 integration CI (added in #27) now covers each.

1. **`UPSERT INTO <table> [ {...}, {...} ]`** → per-record \`UPSERT <id> CONTENT \$item_N\`. Strips redundant \`id\` from payload. Closes #32.
2. **`SELECT * FROM <-edge<-record`** → \`SELECT * FROM record<-edge\`. Affects \`find_mutual_connections\`, \`degree_of\`, \`get_incoming_edges\`, \`count_related\`, internal path-reconstruct helper. Closes #33.
3. **`SELECT * FROM <from>->edge{depth}->`** → \`<from>(->edge->?){depth}\`. Affects \`find_shortest_path\`, \`shortest_path\`, \`get_neighbors\`, and the \`GraphQuery\` depth suffix on \`out\` / \`in_\` / \`both\`. Closes #34.

## Test plan

- [x] \`uv run ruff check src tests\`
- [x] \`uv run mypy src\`
- [x] \`uv run pytest tests/ --ignore=tests/integration\` — **2414 passed**, 9 skipped (12 prior failures in \`test_batch.py\` + \`test_query_graph.py\` were caused by v2-form assertions; updated to pin the v3-safe forms as regressions)
- [x] Integration tests in \`tests/integration/test_v3_happy_path.py\`:
  - \`TestUpsertManyV3::test_upsert_many_round_trips_on_v3\`
  - \`TestIncomingEdgesV3::test_get_incoming_edges_on_v3\`
  - \`TestShortestPathV3::test_shortest_path_on_v3\`

Will run against \`surrealdb/surrealdb:v3.0.5\` in CI via the integration workflow.

Refs #9, closes #32 #33 #34.