### PR TITLE
chore(format): ruff format v3-fix commits

### DIFF
--- a/src/surql/migration/history.py
+++ b/src/surql/migration/history.py
@@ -65,7 +65,6 @@ def _is_table_missing_error(err: Exception) -> bool:
   return 'does not exist' in msg or 'not found' in msg
 
 
-
 async def create_migration_table(client: DatabaseClient) -> None:
   """Create the migration history table if it doesn't exist.
 

--- a/tests/integration/test_v3_happy_path.py
+++ b/tests/integration/test_v3_happy_path.py
@@ -267,9 +267,7 @@ class TestUpsertManyV3:
   """Bug #32: `upsert_many` must emit per-record `UPSERT id CONTENT`."""
 
   @pytest.mark.anyio
-  async def test_upsert_many_round_trips_on_v3(
-    self, integration_client: DatabaseClient
-  ) -> None:
+  async def test_upsert_many_round_trips_on_v3(self, integration_client: DatabaseClient) -> None:
     """Two records upserted; readback returns both."""
     from surql.query.batch import upsert_many
 
@@ -297,9 +295,7 @@ class TestIncomingEdgesV3:
   """Bug #33: incoming-edge queries must anchor the record on the left."""
 
   @pytest.mark.anyio
-  async def test_get_incoming_edges_on_v3(
-    self, integration_client: DatabaseClient
-  ) -> None:
+  async def test_get_incoming_edges_on_v3(self, integration_client: DatabaseClient) -> None:
     """A `follow` edge from alice to bob; `get_incoming_edges(bob, 'follow')` returns one row."""
     from surql.query.graph import get_incoming_edges
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -538,7 +538,7 @@ class TestBuildUpsertQuery:
     # ``id`` should be stripped from the per-record CONTENT payload:
     # v3 rejects a redundant ``id`` field when targeting a specific
     # record.
-    assert "id:" not in query.replace('user:1', '')
+    assert 'id:' not in query.replace('user:1', '')
 
   def test_build_upsert_query_multiple_items(self) -> None:
     """Test building upsert query with multiple items."""


### PR DESCRIPTION
Three files modified in PRs #29 and #35 weren't `ruff format`-clean. Running the formatter produces only whitespace/wrap changes; no behaviour change.