### PR TITLE
chore(dev): add pre-push git hook mirroring CI checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# pre-push: run the same checks as .github/workflows/ci.yml before the push
+# reaches GitHub Actions. CI minutes cost money — fail locally first.
+#
+# Opt in to the integration suite by exporting SURQL_PRE_PUSH_INTEGRATION=1
+# and booting the v3.0.5 container:
+#
+#   docker run -d -p 8000:8000 --name surrealdb surrealdb/surrealdb:v3.0.5 \
+#     start --user root --pass root memory
+#
+# Bypass (rarely): `git push --no-verify` — only when explicitly authorised.
+
+set -euo pipefail
+
+echo "[pre-push] ruff check"
+uv run ruff check src tests
+
+echo "[pre-push] ruff format --check"
+uv run ruff format --check src tests
+
+echo "[pre-push] mypy src"
+uv run mypy src
+
+echo "[pre-push] pytest (unit)"
+uv run pytest --ignore=tests/integration -q
+
+if [[ "${SURQL_PRE_PUSH_INTEGRATION:-0}" == "1" ]]; then
+  echo "[pre-push] pytest (integration, SURQL_PRE_PUSH_INTEGRATION=1)"
+  uv run pytest tests/integration -q
+else
+  echo "[pre-push] skipping integration tests (set SURQL_PRE_PUSH_INTEGRATION=1 to run)"
+fi
+
+echo "[pre-push] all checks passed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+
+## Local pre-push hook
+
+This repo ships a `.githooks/pre-push` that runs the same checks GitHub Actions runs (ruff, mypy, pytest). Wire it up once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Integration tests (against a local `surrealdb/surrealdb:v3.0.5` container) are opt-in:
+
+```bash
+export SURQL_PRE_PUSH_INTEGRATION=1
+docker run -d -p 8000:8000 --name surrealdb surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+```
+
+Bypass (rarely, only with authorisation):
+
+```bash
+git push --no-verify
+```


### PR DESCRIPTION
Implements #49. Hook runs the same ruff + mypy + pytest checks as `ci.yml` before the push hits GitHub. Opt-in integration tests via `SURQL_PRE_PUSH_INTEGRATION=1`.

Smoke-tested locally: 2486 passed, 9 skipped.

One-time setup documented in CONTRIBUTING.md.

Closes #49.