### PR TITLE
chore(release): v1.5.1 — docs refresh

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,94 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-04-18
+
+### Documentation
+
+- **v3 patterns page** (`docs/v3-patterns.md`): datetime cast, `count() GROUP ALL`,
+  `type::record` vs `type::thing`, buffered `BEGIN`/`COMMIT`, idempotent DDL, graph
+  depth unrolling, and v3 integration CI setup.
+- **Query UX helpers page** (`docs/query-ux.md`): before/after examples for every
+  1.5.0 helper -- `type_record`/`type_thing`, function factories
+  (`time_now_fn`, `math_*_fn`, `string_*`, `count_if`), result aliases
+  (`extract_many`, `has_result`), `aggregate_records`, and the `Query.set(...)` /
+  deferred-`update()` / expression-aware `select(...)` builder extensions.
+- **Upgrade notes page** (`docs/migration.md`): 1.3.1 -> 1.4.0 -> 1.5.0 -> 1.5.1
+  call-site migration guide.
+- **CLI reference**: documented the `surql orchestrate deploy | status | validate`
+  subcommands and added a command-group matrix to the overview.
+- **README**: refreshed top-level examples to use the 1.5.0 first-class helpers.
+- **Navigation**: new pages added to `mkdocs.yml` under `Getting Started` and
+  `Guides`.
+
+### Fixed
+
+- Aligned `surql.__version__` with `pyproject.toml`.
+
+## [1.5.0] - 2026-04-16
+
+### Added
+
+- **Record-ID helpers** (#47 / #2): `type_record(table, id)` and
+  `type_thing(table, id)` return `SurrealFn` wrappers. Prefer `type_record` on
+  v3; `type_thing` remains supported for v2 targets.
+- **SurrealFn function factories** (#47 / #3): `time_now_fn`, `math_mean_fn`,
+  `math_sum_fn`, `math_min_fn`, `math_max_fn`, `math_ceil_fn`, `math_floor_fn`,
+  `math_round_fn`, `math_abs_fn`, `string_len`, `string_concat`, `string_lower`,
+  `string_upper`, `count_if`. Each composes with `Query.set(...)`,
+  `Query.select([...])`, and `aggregate_records(select={...})` without raw
+  SurrealQL strings.
+- **Result extraction aliases** (#47 / #4): `extract_many` (alias for
+  `extract_result`) and `has_result` (alias for `has_results`) for naming that
+  reads naturally next to `extract_one` / `extract_scalar`.
+- **`aggregate_records`** (#47 / #1): typed `SELECT ... GROUP BY | GROUP ALL`
+  helper that returns a list of dicts, hiding the SurrealDB response envelope.
+- **Builder API**: `Query.set(**fields)` for fluent `SET` clauses, optional
+  `data` argument on `Query.update(target, data=None)`, and projection items in
+  `Query.select(...)` may now be `SurrealFn` / `Expression` instances (anything
+  with `.to_surql()`).
+- **Pre-push hook**: shipped `.githooks/pre-push` mirroring CI checks (ruff,
+  mypy, pytest) with optional v3 integration opt-in. See `CONTRIBUTING.md` for
+  setup.
+
+## [1.4.0] - 2026-04-15
+
+### Added
+
+- **SurrealDB v3 support**: library now emits SurrealQL accepted by both v2 and
+  v3 servers. No public Python API changes.
+- **Datetime cast on `_migration_history`**: `record_migration()` emits
+  `applied_at = <datetime> $applied_at` so v3 accepts the bootstrap insert.
+- **Buffered `BEGIN`/`COMMIT`**: `DatabaseClient.execute()` now batches
+  transaction-scoped statements into a single RPC frame so v3 honours the
+  commit.
+- **`GROUP ALL` on `count_records`**: `count_records()` appends `GROUP ALL` and
+  accepts both envelope and bare-list response shapes.
+- **`type::record`**: select record-ID targets route through `type::record(...)`
+  on v3 (with `type::thing` still accepted for backwards compatibility).
+- **Idempotent DDL**: `DEFINE TABLE _migration_history IF NOT EXISTS` and the
+  `if_not_exists` flag across the schema generator so `surql migrate up` is safe
+  to re-run.
+- **Graph depth unrolling**: `traverse(...)` unrolls `{min..max}` graph-depth
+  ranges into literal hop unions that v3 accepts.
+- **SDK pin**: minimum `surrealdb` SDK bumped to v2.0.0a1 (speaks v3's RPC
+  protocol).
+- **CI**:
+  - `v3-integration.yml` runs the integration suite against
+    `surrealdb/surrealdb:v3.0.5` on every push.
+  - Nightly matrix runs against `surrealdb/surrealdb:latest`.
+  - Dependabot for pip + github-actions.
+  - Conventional-commit PR title lint.
+  - Dependency-review workflow.
+  - Scheduled `pip-audit` security workflow.
+
+### Fixed
+
+- Narrow `is_migration_applied` probe to a targeted query (avoids false
+  negatives on fresh databases).
+- Narrow migration-table-missing probe to `does not exist` errors (other errors
+  now propagate).
+
 ## [1.3.1] - 2026-04-13
 
 ### Fixed
@@ -300,6 +388,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.5.1]: https://github.com/Oneiriq/surql-py/releases/tag/v1.5.1
+[1.5.0]: https://github.com/Oneiriq/surql-py/releases/tag/v1.5.0
+[1.4.0]: https://github.com/Oneiriq/surql-py/releases/tag/v1.4.0
+[1.3.1]: https://github.com/Oneiriq/surql-py/releases/tag/v1.3.1
 [1.2.1]: https://github.com/Oneiriq/surql-py/releases/tag/v1.2.1
 [1.2.0]: https://github.com/Oneiriq/surql-py/releases/tag/v1.2.0
 [1.1.0]: https://github.com/Oneiriq/surql-py/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 
 - **Code-First Migrations** - Schema changes defined in code with automatic migration generation
 - **Type-Safe Query Builder** - Composable queries with Pydantic model integration
+- **SurrealDB v3 Ready** - Emits v3-correct SurrealQL (datetime casts, `count() GROUP ALL`, `type::record`, buffered transactions, idempotent DDL)
+- **Query UX Helpers** - First-class wrappers for `time::now`, `math::*`, `string::*`, `count_if`, `type_record`, and typed aggregations -- no raw SurrealQL required
 - **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
 - **Graph Traversal** - Native SurrealDB graph features with edge relationships
 - **Query Caching** - Memory and Redis-backed caching with `@cache_query` decorator
 - **Live Queries** - Real-time change notifications and streaming
 - **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams
-- **CLI Tools** - Migrations, schema inspection, validation, and database management
+- **CLI Tools** - Migrations, schema inspection, multi-environment orchestration, validation, and database management
 - **Async-First** - Built with async/await, connection pooling, and retry logic
 
-## Quick Start
+## Install
 
 ```shell
 pip install oneiriq-surql
@@ -26,6 +28,10 @@ pip install oneiriq-surql
 # or with uv
 uv add oneiriq-surql
 ```
+
+## Quick Start
+
+### Define a schema
 
 ```python
 from surql.schema.fields import string_field, int_field, datetime_field
@@ -44,20 +50,75 @@ user_schema = table_schema(
 )
 ```
 
+### Run migrations
+
 ```shell
 surql migrate create "Add user table"
 surql migrate up
 surql migrate status
 ```
 
+### Build queries with first-class helpers
+
+```python
+from surql import (
+  Query,
+  aggregate_records,
+  count_if,
+  math_mean_fn,
+  math_sum_fn,
+  time_now_fn,
+  type_record,
+)
+
+# Fluent UPDATE with server-side function values
+sql = (
+  Query()
+    .update('user:alice')
+    .set(status='active', last_seen=time_now_fn())
+    .to_surql()
+)
+
+# Typed aggregate -- GROUP ALL + count() rendered correctly for v3
+rows = await aggregate_records(
+  table='order',
+  select={
+    'total': count_if(),
+    'revenue': math_sum_fn('amount'),
+    'avg_ticket': math_mean_fn('amount'),
+  },
+  where="status = 'paid'",
+  group_all=True,
+)
+
+# Record-ID construction without string concatenation
+ref = type_record('user', 'alice').to_surql()
+# -> type::record('user', 'alice')
+```
+
+### Deploy across environments
+
+```shell
+# Sequential deploy to staging then production
+surql orchestrate deploy -e staging,production
+
+# Rolling deploy in batches of 2
+surql orchestrate deploy -e prod1,prod2,prod3,prod4 \
+  --strategy rolling --batch-size 2
+```
+
 ## Documentation
 
-Full documentation at **[oneiriq.github.io/surql-py](https://oneiriq.github.io/surql-py/)**.
+Full documentation at **[oneiriq.github.io/surql-py](https://oneiriq.github.io/surql-py/)**:
+
+- [SurrealDB v3 patterns](https://oneiriq.github.io/surql-py/v3-patterns/) -- the forms surql emits for v3 compatibility
+- [Query UX helpers](https://oneiriq.github.io/surql-py/query-ux/) -- typed wrappers for common SurrealQL calls
+- [Upgrade notes](https://oneiriq.github.io/surql-py/migration/) -- 1.3.1 -> 1.4.0 -> 1.5.0 -> 1.5.1
 
 ## Requirements
 
 - Python 3.12+
-- SurrealDB 1.0+
+- SurrealDB 1.0+ (integration CI runs against SurrealDB v3.0.5)
 
 ## License
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -192,7 +192,8 @@ High-level CRUD operations.
 - `delete_record()` - Delete a record
 - `delete_records()` - Delete multiple records
 - `query_records()` - Query with filters
-- `count_records()` - Count records
+- `count_records()` - Count records (emits `count() ... GROUP ALL` for v3)
+- `aggregate_records()` - Typed `SELECT ... GROUP BY | GROUP ALL` returning list-of-dicts (added in 1.5.0)
 - `exists()` - Check if record exists
 - `first()` - Get first matching record
 - `last()` - Get last matching record
@@ -205,6 +206,29 @@ from surql.query.crud import create_record, query_records
 user = await create_record('user', user_data, client=client)
 users = await query_records('user', User, conditions=['age >= 18'], client=client)
 ```
+
+#### `functions.py`
+
+Pre-built SurrealQL function factories returning `SurrealFn` wrappers. Each factory composes with `Query.set(...)`, `Query.select([...])`, and `aggregate_records(select={...})`.
+
+**Time:**
+
+- `time_now_fn()` - `time::now()`
+
+**Math:**
+
+- `math_mean_fn(field)`, `math_sum_fn(field)`, `math_min_fn(field)`, `math_max_fn(field)`
+- `math_ceil_fn(field)`, `math_floor_fn(field)`, `math_round_fn(field, precision=None)`, `math_abs_fn(field)`
+
+**Strings:**
+
+- `string_len(field)`, `string_concat(*parts)`, `string_lower(field)`, `string_upper(field)`
+
+**Aggregation:**
+
+- `count_if(predicate=None)` - renders `count()` or `count(<predicate>)` (v3 rejects `count(*)`)
+
+See the [Query UX Helpers guide](../query-ux.md) for worked examples.
 
 #### `results.py`
 
@@ -222,9 +246,11 @@ Result wrapper classes and extraction utilities for SurrealDB responses.
 **Result Extraction Utilities (SurrealDB Response Format Handling):**
 
 - `extract_result(result)` - Extract data from nested/flat SurrealDB response formats
+- `extract_many(result)` - Alias for `extract_result` (naming parity with `extract_one` / `extract_scalar`, added in 1.5.0)
 - `extract_one(result)` - Extract first record or None
 - `extract_scalar(result, key, default)` - Extract scalar value from aggregate queries
 - `has_results(result)` - Check if result contains any records
+- `has_result(result)` - Alias for `has_results` (added in 1.5.0)
 
 **Example:**
 
@@ -464,6 +490,22 @@ Query operators for type-safe conditions.
 - `contains()` - String contains operator
 - `in_list()` - IN operator
 
+#### `surreal_fn.py`
+
+Raw SurrealQL function-call wrapper that renders verbatim when used as a value.
+
+**Key Classes:**
+
+- `SurrealFn` - Immutable wrapper whose `.to_surql()` emits the bare function expression
+
+**Key Functions:**
+
+- `surql_fn(name, *args)` - Build a `SurrealFn` from a function name and arguments
+- `type_record(table, id)` - Build `type::record('table', id)` (v3-preferred form)
+- `type_thing(table, id)` - Build `type::thing('table', id)` (v2-compatible alias)
+
+See [Query UX Helpers](../query-ux.md#type_record-type_thing) for composition examples.
+
 ## CLI Module
 
 **Location:** `src/cli/`
@@ -499,8 +541,24 @@ Database management commands.
 
 **Commands:**
 
+- `db init` - Initialize database and create migration tracking table
 - `db ping` - Check database connection
 - `db info` - Show database information
+- `db reset` - Reset database by removing all tables
+- `db query` - Execute a raw SurrealQL query
+- `db version` - Show database version information
+
+#### `orchestrate.py`
+
+Multi-database orchestration commands.
+
+**Commands:**
+
+- `orchestrate deploy` - Deploy migrations across environments (sequential, parallel, rolling, canary)
+- `orchestrate status` - Check deployment status of environments
+- `orchestrate validate` - Validate environment configuration and connectivity
+
+See the [CLI Reference](../cli.md#orchestrate-commands) for full options.
 
 #### `common.py`
 
@@ -602,5 +660,8 @@ mypy src/
 - [Schema Definition Guide](../schema.md)
 - [Migration System Guide](../migrations.md)
 - [Query Builder Guide](../queries.md)
-- [CLI Reference](../cli.md)
+- [Query UX Helpers](../query-ux.md) - typed wrappers for `time::now`, `math::*`, `string::*`, `count_if`, `type_record`, and `aggregate_records`
+- [SurrealDB v3 Patterns](../v3-patterns.md) - v3-required SurrealQL forms
+- [Upgrade Notes](../migration.md) - 1.3.1 -> 1.4.0 -> 1.5.0 -> 1.5.1 migration guide
+- [CLI Reference](../cli.md) - `migrate`, `schema`, `db`, `orchestrate` subcommands
 - [Examples](../examples/index.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,17 +9,27 @@ Complete reference for the surql command-line interface.
 - [Migration Commands](#migration-commands)
 - [Schema Commands](#schema-commands)
 - [Database Commands](#database-commands)
+- [Orchestrate Commands](#orchestrate-commands)
 - [Common Workflows](#common-workflows)
 - [Configuration](#configuration)
 - [Environment Variables](#environment-variables)
 
 ## Overview
 
-The surql CLI provides commands for managing database schemas, migrations, and inspecting your database.
+The surql CLI provides commands for managing database schemas, migrations, multi-environment orchestration, and database inspection.
 
 ```shell
 surql [OPTIONS] COMMAND [ARGS]
 ```
+
+### Command Groups
+
+| Group | Purpose |
+| --- | --- |
+| `surql migrate` | Generate, apply, validate, squash, and roll back migrations. |
+| `surql schema` | Inspect, diff, export, and visualise the database schema. |
+| `surql db` | Initialise, ping, query, and reset the database. |
+| `surql orchestrate` | Deploy migrations across multiple environments with rollout strategies. |
 
 ### Getting Help
 
@@ -481,6 +491,92 @@ Connection:
 
 Tables: 5
 Migrations Applied: 3
+```
+
+## Orchestrate Commands
+
+Deploy migrations across multiple database environments with sequential, parallel, rolling, or canary rollout strategies.
+
+```shell
+surql orchestrate [COMMAND] [OPTIONS]
+```
+
+Every subcommand reads its environment list from `environments.json` in the current directory (override with `--config`). Each entry in the config maps a name (e.g. `staging`, `prod1`) to a full `ConnectionConfig` block.
+
+### `orchestrate deploy`
+
+Roll a batch of migrations out to one or more environments.
+
+```shell
+surql orchestrate deploy --environments <names> [OPTIONS]
+```
+
+**Options:**
+
+- `--environments, -e TEXT` - Comma-separated environment names (required)
+- `--strategy TEXT` - `sequential` | `parallel` | `rolling` | `canary` (default: `sequential`)
+- `--batch-size INTEGER` - Batch size for `rolling` strategy (default: `1`)
+- `--canary-percent FLOAT` - Canary percentage for `canary` strategy (default: `10.0`)
+- `--max-concurrent INTEGER` - Max concurrent deployments for `parallel` strategy (default: `5`)
+- `--dry-run` - Simulate the deployment without executing
+- `--skip-health-check` - Skip post-deploy health verification
+- `--no-rollback` - Disable auto-rollback on failure
+- `--config PATH` - Environment configuration file (default: `environments.json`)
+- `--migrations-dir, -m PATH` - Migrations directory (default: `migrations`)
+
+**Examples:**
+
+```shell
+# Deploy sequentially to staging then production
+surql orchestrate deploy -e staging,production
+
+# Rolling deploy in batches of 2
+surql orchestrate deploy -e prod1,prod2,prod3,prod4 \
+  --strategy rolling --batch-size 2
+
+# Canary to 20% of instances first
+surql orchestrate deploy -e prod1,prod2,prod3,prod4,prod5 \
+  --strategy canary --canary-percent 20
+
+# Dry run against production
+surql orchestrate deploy -e production --dry-run
+```
+
+### `orchestrate status`
+
+Report the current applied-migration state across environments.
+
+```shell
+surql orchestrate status --environments <names> [OPTIONS]
+```
+
+**Options:**
+
+- `--environments, -e TEXT` - Comma-separated environment names (required)
+- `--config PATH` - Environment configuration file (default: `environments.json`)
+
+**Example:**
+
+```shell
+surql orchestrate status -e prod1,prod2,prod3
+```
+
+### `orchestrate validate`
+
+Validate the environment configuration file and confirm connectivity to each environment.
+
+```shell
+surql orchestrate validate [OPTIONS]
+```
+
+**Options:**
+
+- `--config PATH` - Environment configuration file (default: `environments.json`)
+
+**Example:**
+
+```shell
+surql orchestrate validate --config prod-environments.json
 ```
 
 ## Common Workflows

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,117 @@
+# Upgrade Notes
+
+This page covers upgrade steps from each recent release. Each section lists the shipping changes and the call-site updates most projects will want to make. Nothing in 1.4.x or 1.5.x is a breaking API change; everything is additive or strictly a bug fix, so upgrades should be drop-in.
+
+Releases:
+
+- [1.5.1 -- docs refresh](#151-docs-refresh)
+- [1.5.0 -- query UX](#150-query-ux)
+- [1.4.0 -- SurrealDB v3 support](#140-surrealdb-v3-support)
+- [1.3.1 -- embedded migration fix](#131-embedded-migration-fix)
+
+## 1.5.1 -- docs refresh
+
+Patch release. No code changes; docs-site only.
+
+- New pages: [SurrealDB v3 patterns](v3-patterns.md), [Query UX helpers](query-ux.md), and this upgrade guide.
+- CLI reference extended to cover `surql orchestrate` subcommands.
+- README examples rewritten to use the 1.5.0 helpers.
+- `__version__` aligned to `pyproject.toml`.
+
+No action required.
+
+## 1.5.0 -- query UX
+
+Additive. All previous call shapes keep working.
+
+### What's new
+
+- **Record-ID helpers**: `type_record(table, id)` / `type_thing(table, id)` return `SurrealFn` wrappers for the two SurrealDB record-construction builtins.
+- **Function factories**: `time_now_fn`, `math_mean_fn`, `math_sum_fn`, `math_min_fn`, `math_max_fn`, `math_ceil_fn`, `math_floor_fn`, `math_round_fn`, `math_abs_fn`, `string_len`, `string_concat`, `string_lower`, `string_upper`, `count_if`. Each returns a `SurrealFn` that composes with `Query.set(...)`, `Query.select([...])`, and `aggregate_records(select={...})`.
+- **Result helpers**: `extract_many` (alias for `extract_result`) and `has_result` (alias for `has_results`).
+- **`aggregate_records`**: typed `SELECT ... GROUP BY | GROUP ALL` helper returning list-of-dicts.
+- **Builder API**: `Query.set(**fields)`, `Query.update(target, data=None)`, and `Query.select(...)` now accepts `SurrealFn` / `Expression` projection items alongside strings.
+
+### Recommended call-site updates
+
+Before:
+
+```python
+await client.execute(
+  "SELECT count(*) AS total, math::sum(amount) AS revenue "
+  "FROM order WHERE status = 'paid' GROUP ALL"
+)
+```
+
+After:
+
+```python
+from surql import aggregate_records, count_if, math_sum_fn
+
+rows = await aggregate_records(
+  table='order',
+  select={
+    'total': count_if(),
+    'revenue': math_sum_fn('amount'),
+  },
+  where="status = 'paid'",
+  group_all=True,
+)
+```
+
+Before:
+
+```python
+await client.execute(
+  "UPDATE user:alice SET status = 'active', last_seen = time::now()"
+)
+```
+
+After:
+
+```python
+from surql import Query, time_now_fn
+
+sql = (
+  Query()
+    .update('user:alice')
+    .set(status='active', last_seen=time_now_fn())
+    .to_surql()
+)
+await client.execute(sql)
+```
+
+See [Query UX helpers](query-ux.md) for the full surface with before/after side-by-side examples.
+
+## 1.4.0 -- SurrealDB v3 support
+
+Additive at the Python API level. The SurrealQL emitted by the library changed to forms that both v2 and v3 accept. No user-visible code changes are required; the behaviour differences below are worth being aware of.
+
+### What's new
+
+- **Datetime cast on `_migration_history`**: `record_migration()` now writes `applied_at = <datetime> $applied_at`.
+- **Buffered `BEGIN`/`COMMIT`**: `DatabaseClient.execute()` batches transaction-scoped statements into a single RPC frame so v3 honours the commit.
+- **`GROUP ALL` on `count_records`**: `count_records()` now appends `GROUP ALL` so v3 accepts the aggregate. The helper still accepts both the envelope shape and a bare scalar list from the SDK.
+- **`type::record` over `type::thing`**: select record-ID targets route through `type::record(...)` on v3. `type_record` is now preferred over `type_thing` in new code.
+- **Idempotent DDL**: `DEFINE TABLE _migration_history IF NOT EXISTS` (and the `if_not_exists` flag across the schema generator) so `surql migrate up` is safe to re-run.
+- **Graph depth unrolling**: `traverse(...)` unrolls `{min..max}` depth ranges into literal hop unions that v3 accepts.
+- **SDK pin**: minimum `surrealdb` SDK bumped to v2.0.0a1, which speaks v3's RPC protocol.
+- **CI**: new `v3-integration` workflow runs the integration suite against `surrealdb/surrealdb:v3.0.5`; nightly matrix runs against `surrealdb/surrealdb:latest`.
+
+### Recommended call-site updates
+
+Nothing is required to keep 1.3.x code running. If you hand-write SurrealQL anywhere (raw `client.execute()` calls), audit for the v3-required forms:
+
+- Replace `count(*)` with `count()` and add `GROUP ALL` to any full-table aggregate. See [v3 patterns: count() aggregates](v3-patterns.md#count-aggregates-require-group-all).
+- Cast datetime literals explicitly: `<datetime> $value` or `<datetime> '2026-...'`. See [v3 patterns: datetime cast](v3-patterns.md#datetime-cast-on-insert).
+- Prefer `type::record('table', id)` over `type::thing('table', id)` for new expressions. See [v3 patterns: record-ID construction](v3-patterns.md#record-id-construction-typerecord-not-typething).
+- Ensure `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` is issued in a single `client.execute(...)` call, or use the `transaction()` context manager which already does so.
+
+## 1.3.1 -- embedded migration fix
+
+Bug-fix release for embedded engines (`mem://`, `memory://`, `file://`, `surrealkv://`).
+
+- `execute_migration()` now detects embedded URL schemes and skips the `BEGIN TRANSACTION` / `COMMIT TRANSACTION` wrapper; the upstream SDK's `query()` returns an empty list for transaction-control statements in embedded mode, which previously surfaced as `IndexError: list index out of range`.
+- Migrations remain effectively atomic in embedded mode because the engine lives in the host process; a crash during migration takes the process with it rather than leaving a partial schema.
+
+No action required. Existing remote (`ws://`, `http://`) connections retain the transactional wrapper.

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,0 +1,281 @@
+# Query UX Helpers
+
+surql 1.5.0 added a layer of first-class helpers that replace hand-written SurrealQL strings for the most common call sites. Each helper returns a `SurrealFn` wrapper or a plain function that composes with the existing `Query` builder, the CRUD helpers, and raw `client.execute()` calls.
+
+Every example below shows the raw SurrealQL you used to have to write and the typed equivalent.
+
+## Why bother?
+
+- **Correctness under v3** — `type::record` vs `type::thing`, `count()` vs `count(*)`, explicit `<datetime>` casts, and `GROUP ALL` are all easy to forget. The helpers emit the correct form by default.
+- **Composability** — helpers return `SurrealFn` instances, so they slot into `Query.select([...])`, `Query.set(**kwargs)`, `aggregate_records(select={...})`, and `client.execute(params=...)` without double-escaping.
+- **Refactorability** — renaming a field no longer means a grep across string-concatenated SurrealQL; the helpers take parameters, not literals.
+
+## `type_record` / `type_thing`
+
+Build `type::record('table', id)` / `type::thing('table', id)` expressions without string concatenation.
+
+```python
+from surql import type_record, type_thing, RecordID
+
+# Before
+raw = "type::record('user', 'alice')"
+
+# After
+type_record('user', 'alice').to_surql()
+# -> "type::record('user', 'alice')"
+
+# Integers render unquoted
+type_record('post', 42).to_surql()
+# -> "type::record('post', 42)"
+
+# RecordID and SurrealFn arguments render verbatim (no double-quoting)
+type_record('edge', RecordID(table='user', id='alice')).to_surql()
+# -> "type::record('edge', user:alice)"
+
+# Legacy v2 form, still accepted by v3
+type_thing('user', 'alice').to_surql()
+# -> "type::thing('user', 'alice')"
+```
+
+Prefer `type_record` for new code (see [v3 patterns](v3-patterns.md#record-id-construction-typerecord-not-typething)); `type_thing` exists for callers that still target v2 servers.
+
+## Function factories (`SurrealFn`)
+
+The `surql.query.functions` module exposes factories that wrap common SurrealDB built-ins as `SurrealFn` values. Every factory is re-exported from the package root.
+
+### Time
+
+| Helper | Renders as |
+| --- | --- |
+| `time_now_fn()` | `time::now()` |
+
+```python
+from surql import Query, time_now_fn, update
+
+# Before
+await client.execute(
+  'UPDATE user:alice SET last_seen = time::now()'
+)
+
+# After (builder)
+sql = (
+  Query()
+    .update('user:alice')
+    .set(last_seen=time_now_fn())
+    .to_surql()
+)
+# -> UPDATE user:alice SET last_seen = time::now()
+```
+
+### Math
+
+| Helper | Renders as |
+| --- | --- |
+| `math_mean_fn(field)` | `math::mean(<field>)` |
+| `math_sum_fn(field)` | `math::sum(<field>)` |
+| `math_min_fn(field)` | `math::min(<field>)` |
+| `math_max_fn(field)` | `math::max(<field>)` |
+| `math_ceil_fn(field)` | `math::ceil(<field>)` |
+| `math_floor_fn(field)` | `math::floor(<field>)` |
+| `math_round_fn(field, precision=None)` | `math::round(<field>[, <precision>])` |
+| `math_abs_fn(field)` | `math::abs(<field>)` |
+
+```python
+from surql import Query, aggregate_records, math_mean_fn, math_sum_fn
+
+# Before
+await client.execute(
+  'SELECT math::mean(score) AS avg_score, '
+  'math::sum(score) AS total_score FROM run '
+  'GROUP ALL'
+)
+
+# After
+await aggregate_records(
+  table='run',
+  select={
+    'avg_score': math_mean_fn('score'),
+    'total_score': math_sum_fn('score'),
+  },
+  group_all=True,
+)
+```
+
+### Strings
+
+| Helper | Renders as |
+| --- | --- |
+| `string_len(field)` | `string::len(<field>)` |
+| `string_concat(*parts)` | `string::concat(<parts...>)` |
+| `string_lower(field)` | `string::lowercase(<field>)` |
+| `string_upper(field)` | `string::uppercase(<field>)` |
+
+```python
+from surql import Query, string_concat, string_upper
+
+sql = (
+  Query()
+    .update('user:alice')
+    .set(display_name=string_concat(string_upper('first_name'), "' '", 'last_name'))
+    .to_surql()
+)
+# -> UPDATE user:alice SET display_name = string::concat(string::uppercase(first_name), ' ', last_name)
+```
+
+### `count_if`
+
+`count_if(predicate)` renders SurrealDB's `count(<predicate>)` aggregate. Pass `None` or omit to get bare `count()` (v3 rejects `count(*)`).
+
+```python
+from surql import aggregate_records, count_if
+
+# Before
+await client.execute(
+  "SELECT count(status = 'active') AS active_count FROM user GROUP ALL"
+)
+
+# After
+await aggregate_records(
+  table='user',
+  select={'active_count': count_if("status = 'active'")},
+  group_all=True,
+)
+```
+
+## Result extraction aliases
+
+SurrealDB returns three shapes depending on the call path:
+
+- Direct records: `[{"id": "...", ...}, ...]`
+- Wrapped envelope: `[{"result": [...], "time": "..."}]`
+- Scalar aggregate: `[{"count": 5}]`
+
+The extraction helpers normalise all three.
+
+| Helper | Description |
+| --- | --- |
+| `extract_result(result)` | Return list of records (all shapes). |
+| `extract_many(result)` | Alias for `extract_result` that reads naturally next to `extract_one`. |
+| `extract_one(result)` | Return the first record, or `None`. |
+| `extract_scalar(result, key, default)` | Return the named scalar from an aggregate result. |
+| `has_results(result)` | `True` if the response contains any row. |
+| `has_result(result)` | Alias for `has_results`. |
+
+```python
+from surql import extract_many, extract_one, has_result
+
+raw = await client.execute('SELECT * FROM user WHERE active = true')
+
+if has_result(raw):
+  users = extract_many(raw)
+  first = extract_one(raw)
+```
+
+Prefer the aliased names (`extract_many`, `has_result`) in new code — they read more naturally next to `extract_one` and `extract_scalar`. The originals remain exported for backwards compatibility.
+
+## `aggregate_records`
+
+`aggregate_records(table, select, group_by=None, group_all=False, where=None)` runs a typed `SELECT ... GROUP BY | GROUP ALL` query and returns rows as plain dicts, hiding the response envelope.
+
+```python
+from surql import aggregate_records, count_if, math_sum_fn
+
+# Before
+raw = await client.execute("""
+  SELECT network,
+         count() AS count,
+         math::sum(strength) AS total_strength
+  FROM memory_entry
+  GROUP BY network
+""")
+rows = extract_result(raw)
+
+# After
+rows = await aggregate_records(
+  table='memory_entry',
+  select={
+    'count': count_if(),
+    'total_strength': math_sum_fn('strength'),
+  },
+  group_by=['network'],
+)
+```
+
+Rules:
+
+- `select` is a mapping of output alias -> projection. Values may be `SurrealFn`, `FunctionExpression`, or raw SurrealQL strings.
+- Exactly one of `group_by=[...]` or `group_all=True` must be provided.
+- `where` accepts a `str` or an `Operator` and renders as the `WHERE` clause.
+- Results come back as a list of dicts, already unwrapped from the SurrealDB envelope.
+
+## Builder API extensions
+
+The `Query` builder gained a small set of ergonomic affordances in 1.5.0.
+
+### `Query.set(**fields)`
+
+Populate the `SET` clause of `UPDATE` / `UPSERT` / `INSERT` without a dict literal. Values may be any literal, plus `SurrealFn` / `Expression` instances for raw SurrealQL.
+
+```python
+from surql import Query, time_now_fn
+
+# Before
+Query().update('user:alice', {'status': 'active', 'last_seen': time_now_fn()})
+
+# After
+(
+  Query()
+    .update('user:alice')
+    .set(status='active', last_seen=time_now_fn())
+)
+```
+
+### `Query.update(target, data=None)`
+
+`data` is now optional. When omitted, the builder defers the `SET` payload so `.set(**fields)` can populate it incrementally.
+
+```python
+from surql import Query
+
+(
+  Query()
+    .update('user:alice')         # no data argument
+    .set(status='active')          # fluent set
+    .where('age >= 18')            # chain additional clauses
+)
+```
+
+### `Query.select(fields)` accepts expressions
+
+Each item in the projection list may now be:
+
+- a raw field name (`'name'`),
+- a pre-rendered SurrealQL fragment (`'count()'`),
+- an `Expression` instance,
+- or a `SurrealFn` instance (rendered verbatim via `to_surql()`).
+
+```python
+from surql import Query, count_if, math_mean_fn, as_
+
+sql = (
+  Query()
+    .select([
+      as_(count_if(), 'active_count'),
+      as_(math_mean_fn('score'), 'avg_score'),
+    ])
+    .from_table('user')
+    .where("status = 'active'")
+    .group_all()
+    .to_surql()
+)
+```
+
+## Compatibility
+
+Everything on this page is additive — the pre-1.5 APIs (`extract_result`, `has_results`, dict-only `Query.update(target, data)`, string-only `Query.select(fields)`) continue to work unchanged. Mix raw SurrealQL and typed helpers freely; they share the same quoting pipeline.
+
+## Further reading
+
+- [SurrealDB v3 patterns](v3-patterns.md) — the v3 forms these helpers emit by default
+- [Migration notes](migration.md) — upgrading existing call sites to the new helpers
+- [Query Builder](queries.md) — the underlying `Query` API

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -1,0 +1,162 @@
+# SurrealDB v3 Patterns
+
+surql 1.4.0 introduced the SurrealQL forms required by SurrealDB v3. The v3 engine is stricter than v2 about datetime coercion, count aggregates, record-ID construction, transaction batching, and DDL idempotence. This page documents the patterns the library emits and explains the forms you should reach for in any raw SurrealQL you still hand-write.
+
+All examples run cleanly against the v3 integration CI (`surrealdb/surrealdb:v3.0.5`, see the `v3-integration` workflow).
+
+## Datetime cast on insert
+
+v3 no longer coerces bare ISO-8601 strings into `datetime` values. Any column typed `datetime` requires an explicit `<datetime>` cast at the call site.
+
+**Before (v2-only):**
+
+```surql
+CREATE _migration_history SET
+  version = '20260102_120000',
+  applied_at = '2026-01-02T12:00:00Z';
+```
+
+**Now (v3-compatible):**
+
+```surql
+CREATE _migration_history SET
+  version = '20260102_120000',
+  applied_at = <datetime> $applied_at;
+```
+
+Driven from Python, this is handled automatically by the migration recorder:
+
+```python
+await client.execute(
+  'CREATE _migration_history SET '
+  'version = $version, applied_at = <datetime> $applied_at',
+  params={'version': version, 'applied_at': '2026-01-02T12:00:00Z'},
+)
+```
+
+## `count()` aggregates require `GROUP ALL`
+
+v3 rejects `count(*)` and also rejects a bare `SELECT count() FROM table` without an explicit grouping. Always append `GROUP ALL` for full-table counts and use `count()` (no `*`).
+
+**Before:**
+
+```surql
+SELECT count(*) AS total FROM user;
+```
+
+**Now:**
+
+```surql
+SELECT count() AS total FROM user GROUP ALL;
+```
+
+The query builder emits the correct form out of the box:
+
+```python
+from surql import Query, count_records
+
+# CRUD helper, used by SurrealDB v3
+await count_records('user')  # -> SELECT count() AS count FROM user GROUP ALL
+
+# Builder, explicit
+(
+  Query()
+  .select(['count()'])
+  .from_table('user')
+  .group_all()
+)
+```
+
+`count_if(predicate)` renders `count(<predicate>)` for conditional counts (see [Query UX helpers](query-ux.md#count_if)).
+
+## Record-ID construction: `type::record`, not `type::thing`
+
+`type::thing('table', 'id')` was renamed to `type::record('table', 'id')` in v3. The `type::thing` name still resolves for backwards compatibility but new code should use `type::record` directly.
+
+**Prefer:**
+
+```python
+from surql import type_record
+
+ref = type_record('user', 'alice').to_surql()
+# -> type::record('user', 'alice')
+```
+
+`type_thing()` is still exported for code that must target older servers, and generates the exact v2 form:
+
+```python
+from surql import type_thing
+
+type_thing('user', 'alice').to_surql()
+# -> type::thing('user', 'alice')
+```
+
+See [Query UX helpers](query-ux.md#type_record-type_thing) for the full helper surface, including composition with `RecordID`, integers, and nested `SurrealFn` arguments.
+
+## Buffered `BEGIN`/`COMMIT` transactions
+
+The v3 RPC protocol dispatches each `client.execute()` call as a separate statement. `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` split across three round trips crashes v3 because later statements run outside the transaction scope and the trailing `COMMIT` has nothing to commit.
+
+`DatabaseClient.execute()` now batches `BEGIN`/`COMMIT` and all statements between them into a single RPC frame. Callers don't have to change anything — the `transaction()` context manager and the migration executor do the right thing automatically:
+
+```python
+from surql import get_client, transaction
+
+async with get_client(config) as client:
+  async with transaction(client):
+    await client.execute('UPDATE user:alice SET credits -= 10')
+    await client.execute('UPDATE user:bob   SET credits += 10')
+  # Emitted as a single BEGIN; ...; COMMIT; RPC.
+```
+
+Embedded engines (`mem://`, `file://`, `surrealkv://`) remain transactional-in-process and skip the wrapper entirely (see `CHANGES` 1.3.1).
+
+## `IF NOT EXISTS` on DDL
+
+v3 treats repeat DDL as an error unless the statement is idempotent. surql emits `DEFINE TABLE ... IF NOT EXISTS`, `DEFINE INDEX ... IF NOT EXISTS`, and `DEFINE FIELD ... IF NOT EXISTS` whenever the generator's `if_not_exists=True` flag is set (the default for the migration history table and the recommended setting for schema generation).
+
+```python
+from surql.schema.table import generate_table_sql
+
+sql = generate_table_sql(user_schema, if_not_exists=True)
+# DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;
+# DEFINE FIELD IF NOT EXISTS email ON user TYPE string ...;
+# DEFINE INDEX IF NOT EXISTS email_idx ON TABLE user COLUMNS email UNIQUE;
+```
+
+The `_migration_history` bootstrap in `ensure_migration_table()` uses this form unconditionally so `surql migrate up` is safe to run repeatedly on a schema-already-bootstrapped database.
+
+## Graph-depth literals
+
+v3 rejects grouped graph-depth syntax such as `->follows{1..3}->user`. Expand to literal hop lists:
+
+```python
+from surql import traverse
+
+# surql unrolls depth ranges into literal hop unions that v3 accepts.
+await traverse('user:alice', '->follows->user', depth=(1, 3), client=client)
+```
+
+## v3 integration CI
+
+The `v3-integration.yml` workflow spins up `surrealdb/surrealdb:v3.0.5` and runs the integration suite on every push. The same suite runs nightly against the latest `surrealdb/surrealdb:latest` image to flag upstream drift early. Opt into the local v3 container via:
+
+```bash
+export SURQL_PRE_PUSH_INTEGRATION=1
+docker run -d -p 8000:8000 --name surrealdb \
+  surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+```
+
+Wire the pre-push hook once per clone so the same checks run before every `git push`:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+See [CONTRIBUTING.md](https://github.com/Oneiriq/surql-py/blob/main/CONTRIBUTING.md) for the full pre-push setup.
+
+## Further reading
+
+- [Query UX helpers](query-ux.md) — the typed helper surface that emits v3-correct SurrealQL without raw strings
+- [Migration notes](migration.md) — upgrading existing v1.3.x code to v1.4.x / v1.5.x
+- [Migrations](migrations.md) — the migration system, including the buffered-transaction wrapper

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Schema Definition: schema.md
       - Migrations: migrations.md
       - Query Builder: queries.md
+      - SurrealDB v3 Patterns: v3-patterns.md
       - Query Hints: query_hints.md
       - Caching: caching.md
       - Streaming: streaming.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Schema Definition: schema.md
       - Migrations: migrations.md
       - Query Builder: queries.md
+      - Query UX Helpers: query-ux.md
       - SurrealDB v3 Patterns: v3-patterns.md
       - Query Hints: query_hints.md
       - Caching: caching.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quick Start: quickstart.md
+      - Upgrade Notes: migration.md
   - Guides:
       - Schema Definition: schema.md
       - Migrations: migrations.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.0"
+version = "1.5.1"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.2.1'
+__version__ = '1.5.1'
 
 __all__ = [
   # Configuration

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
Docs-only patch: mkdocs site synced with v1.4 + v1.5 surface. Ships new v3-patterns, query-ux, cli, migration pages. Refs #53.