### PR TITLE
feat(#58): point CI at aur0 org self-hosted runner

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   audit:
     name: pip-audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         python-version: ['3.12']

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 
@@ -42,7 +42,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   integration:
     name: SurrealDB v3 integration tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
   unit-linux:
     name: Nightly unit linux (Python ${{ matrix.python-version }})
     # Linux runs daily (03:00 cron), weekly (06:00 cron), and on manual dispatch.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:
@@ -92,7 +92,7 @@ jobs:
     # `ubuntu-latest` and fan out on Python + server tag.
     # Skip on the weekly macOS cron — integration already ran on the prior day's Linux cron.
     if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 3 * * *'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   lint-pr-title:
     name: Conventional Commit PR title
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 
@@ -45,7 +45,7 @@ jobs:
         run: uv run pytest --cov=src --cov-report=term-missing
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: test
     steps:
       - uses: actions/checkout@v5
@@ -63,7 +63,7 @@ jobs:
           path: dist/
 
   publish-testpypi:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
     if: >-
       (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi') ||
@@ -84,7 +84,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
     if: >-
       (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi') ||


### PR DESCRIPTION
Closes #58. Retargets `ubuntu-latest` -> `[self-hosted, Linux, X64]` so CI runs on aur0-oneiriq (org-level self-hosted). Zero GitHub-hosted minutes for these jobs.

Merged after this lands: every push/PR on surql-py hits aur0, no billed minutes.