### PR TITLE
chore(audit): bump python-dotenv to 1.2.2 to patch CVE-2026-28684

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1407,11 +1407,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `python-dotenv` **1.2.1 -> 1.2.2** (transitive via `pydantic-settings`) to patch **CVE-2026-28684** / GHSA-mf9w-mj56-hr94.
- Resolves the Security Audit job failure on `main` (was: 1 vuln found, 22 ignored; now: 0 found, 22 ignored).
- Lockfile-only change; no `pyproject.toml` constraints touched and no new direct deps added.

## CVE detail

`rewrite()` in python-dotenv's `set_key()` / `unset_key()` followed symlinks during the cross-device `shutil.move()` fallback, letting a local attacker overwrite arbitrary files writable by the application by pre-placing a symlink at the `.env` path. Fixed upstream in 1.2.2 by writing temp files in the target directory and using `os.replace()` (no symlink follow).

Advisory: https://github.com/theskumar/python-dotenv/security/advisories/GHSA-mf9w-mj56-hr94

## Test plan

- [x] `uv lock --upgrade-package python-dotenv` (only python-dotenv bumped)
- [x] `pip-audit` reproduces upstream finding locally with the workflow's exact `--ignore-vuln` set, then reports `No known vulnerabilities found, 22 ignored` after the bump (exit 0)
- [x] `uv run pytest --cov=src --cov-report=term-missing` passes (parity with `main`; the unit suite is currently all-skipped on this branch tip, same as base)
- [ ] CI Security Audit job goes green
- [ ] CI test/lint/mypy jobs go green