### PR TITLE
chore(security): close code-scanning alerts (workflow permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,9 @@ on:
       - main
       - 'release/**'
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
           - testpypi
           - pypi
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Closes 6 open code-scanning alerts (rule `actions/missing-workflow-permissions`).

Added workflow-level `permissions: contents: read` to:
- `.github/workflows/ci.yml` (line 14)
- `.github/workflows/integration.yml` (line 18)
- `.github/workflows/nightly.yml` (lines 13, 49)
- `.github/workflows/publish.yml` (lines 22, 48)

`publish.yml` keeps job-level `id-token: write` for PyPI Trusted Publishing on the `publish-testpypi` and `publish-pypi` jobs (line 73, 94) -- those override the workflow-level fallback.