### PR TITLE
fix(client): URL false positive in record-ID auto-coercion (1.5.2)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-05-02
+
+### Fixed
+
+- **`_denormalize_params` URL false positive (silent CREATE/UPDATE failures).**
+  The record-ID detection regex `^[a-zA-Z_][a-zA-Z0-9_]*:.+$` matched URL
+  schemes like `http://`, `https://`, `ws://`, `wss://`, `file://`, and
+  silently coerced URL strings into `RecordID` objects. SurrealDB returned a
+  coerce error in the result text of an otherwise OK-status query response,
+  which the wrapper swallowed -- writes that included URL params reported
+  success but never persisted. Added a negative lookahead `(?!//)` after
+  the colon so URL strings round-trip unchanged. Discovered while debugging
+  per-workspace embedder configuration in a downstream consumer
+  (`base_url='http://10.0.0.51:11434'` was being rewritten to
+  `RecordID('http', '//10.0.0.51:11434')`).
+
 ## [1.5.1] - 2026-04-18
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.1"
+version = "1.5.2"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -22,7 +22,17 @@ from surql.connection.config import ConnectionConfig
 logger = structlog.get_logger(__name__)
 
 # Pattern matching SurrealDB record ID targets: "table:id" or "table:<complex_id>"
-_RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:.+$')
+#
+# The negative lookahead ``(?!//)`` after the colon excludes URL schemes
+# (``http://``, ``https://``, ``ws://``, ``wss://``, ``file://``, ...) which
+# share the ``<word>:<rest>`` shape with record-id literals but must NOT be
+# coerced to ``RecordID`` objects. Without this guard, any caller passing a
+# URL parameter (e.g. ``base_url='http://10.0.0.51:11434'``) would have it
+# silently rewritten to ``RecordID('http', '//10.0.0.51:11434')``, which
+# SurrealDB returns a coerce error for in the result text of an otherwise
+# OK-status query response -- the kind of bug that's hard to spot because
+# the Python wrapper sees ``status: 'OK'`` and reports success.
+_RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:(?!//).+$')
 
 
 def _is_record_id_target(target: str) -> bool:

--- a/tests/test_sdk_normalization.py
+++ b/tests/test_sdk_normalization.py
@@ -58,6 +58,54 @@ class TestIsRecordIdTarget:
     """Detects ULID-style record IDs."""
     assert _is_record_id_target('file:01JQXYZ1234ABCDEF5678') is True
 
+  def test_http_url_not_record_id(self) -> None:
+    """URL strings must not be detected as record IDs.
+
+    Regression: ``http://10.0.0.51:11434`` was being silently coerced
+    into ``RecordID('http', '//10.0.0.51:11434')`` because the original
+    pattern accepted any ``<word>:<rest>`` shape.
+    """
+    assert _is_record_id_target('http://10.0.0.51:11434') is False
+
+  def test_https_url_not_record_id(self) -> None:
+    """HTTPS URLs are not record IDs."""
+    assert _is_record_id_target('https://example.com/path') is False
+
+  def test_ws_url_not_record_id(self) -> None:
+    """WebSocket URLs are not record IDs."""
+    assert _is_record_id_target('ws://surrealdb:8000/rpc') is False
+
+  def test_wss_url_not_record_id(self) -> None:
+    """Secure WebSocket URLs are not record IDs."""
+    assert _is_record_id_target('wss://db.example.com/rpc') is False
+
+  def test_file_url_not_record_id(self) -> None:
+    """``file://`` URLs are not record IDs."""
+    assert _is_record_id_target('file:///tmp/foo.json') is False
+
+  def test_url_in_denormalize_params_passthrough(self) -> None:
+    """Param values that look like URLs round-trip unchanged.
+
+    Verifies the regression at the call-site level: ``_denormalize_params``
+    must not touch URL strings, even when they're nested inside dicts.
+    """
+    payload = {
+      'workspace_id': 'workspace:abc',
+      'base_url': 'http://10.0.0.51:11434',
+      'mqtt_url': 'mqtt://10.0.0.100:1883',
+      'nested': {
+        'gateway': 'ws://surrealdb:8000/rpc',
+      },
+    }
+    result = _denormalize_params(payload)
+    assert isinstance(result, dict)
+    # The record-id string still gets coerced
+    assert not isinstance(result['workspace_id'], str)
+    # URLs stay as strings
+    assert result['base_url'] == 'http://10.0.0.51:11434'
+    assert result['mqtt_url'] == 'mqtt://10.0.0.100:1883'
+    assert result['nested']['gateway'] == 'ws://surrealdb:8000/rpc'
+
 
 # ============================================================================
 # _normalize_sdk_value


### PR DESCRIPTION
## Summary

`_denormalize_params` was silently rewriting URL strings into `RecordID` objects because the detection regex only required `<word>:<rest>`. `http://10.0.0.51:11434` matched the same shape as `user:abc123`, so consumers passing URL-shaped params (base_url for an embedding endpoint, MQTT broker URL, WebSocket URL, file://) had their values coerced to `RecordID('http', '//10.0.0.51:11434')`.

SurrealDB returned a coerce error in the result text of an otherwise-OK-status query response; the wrapper swallowed it; writes silently never persisted.

## Fix

Negative lookahead `(?!//)` after the colon. URL schemes no longer match. Real record-id strings (`user:abc`, `file:01JQXYZ...`, `outlet:<alaskabeacon.com>`) keep working.

```diff
-_RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:.+$')
+_RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:(?!//).+$')
```

## Tests

Six new tests in `TestIsRecordIdTarget`:
- `test_http_url_not_record_id`
- `test_https_url_not_record_id`
- `test_ws_url_not_record_id`
- `test_wss_url_not_record_id`
- `test_file_url_not_record_id`
- `test_url_in_denormalize_params_passthrough` — round-trip on a payload mixing record-id strings with URL-shaped params

All 72 tests pass; ruff format/check + mypy --strict clean.

## Discovery

Found while debugging `Oneiriq/kushtakas#213` — per-workspace embedder configuration writes were going through `db.execute(create_query, {'base_url': 'http://10.0.0.51:11434', ...})` and the `workspace_embedding_config` table stayed empty no matter how many times the MCP tool was called. Took some time to track down because the wrapper reported `success: True` while the row never appeared.

## Version bump

`1.5.1` → `1.5.2` (patch). CHANGES updated.