### PR TITLE
fix(ci): switch CI to aur0 self-hosted runner; drop macOS/Windows from push/PR

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   audit:
     name: pip-audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     strategy:
       matrix:
         python-version: ['3.12']

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - name: Get PR metadata
         id: meta

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 
@@ -42,7 +42,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   integration:
     name: SurrealDB v3 integration tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   lint-pr-title:
     name: Conventional Commit PR title
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +48,7 @@ jobs:
         run: uv run pytest --cov=src --cov-report=term-missing
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     needs: test
     steps:
       - uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
           path: dist/
 
   publish-testpypi:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     needs: build
     if: >-
       (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi') ||
@@ -87,7 +87,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     needs: build
     if: >-
       (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi') ||


### PR DESCRIPTION
Stops the GitHub-hosted minute bleed by routing every push/PR-triggered job to the org's `[self-hosted, aur0]` runner. macOS coverage stays on the nightly schedule.

## Per-workflow changes

| Workflow | Before | After |
|---|---|---|
| `ci.yml` | `runs-on: ubuntu-latest` (test job) | `runs-on: [self-hosted, aur0]` |
| `audit.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `dep-review.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `dependabot-auto-merge.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `docs.yml` | `runs-on: ubuntu-latest` (build + deploy) | `runs-on: [self-hosted, aur0]` |
| `integration.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `pr-title.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `publish.yml` | `runs-on: ubuntu-latest` (4 jobs) | `runs-on: [self-hosted, aur0]` |

## Untouched

- `nightly.yml` — keeps `os: [ubuntu-latest, macos-latest]` matrix as the cross-platform safety net for macOS coverage we drop from PR-time.

## Test plan

- [ ] First push to this branch lands on aur0 — confirm runner picks up jobs
- [ ] CI test job, audit, integration, dep-review all green on aur0
- [ ] Pages publish flow (`docs.yml`) still produces a deployable artifact