### PR TITLE
chore(ci): drop scheduled cross-platform jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ['3.12', '3.13']
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Remove unnecessary costs imposed by GitHub Actions.

| File | Action |
| --- | --- |
| `.github/workflows/nightly.yml` | matrix trimmed (drop `macos-latest`) |