### PR TITLE
feat(client): public streaming API on DatabaseClient (1.5.4)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2026-05-02
+
+### Added
+
+- `DatabaseClient.streaming` public property and `DatabaseClient.live(table,
+  diff=False)` convenience method so callers no longer need to reach into
+  the private `_streaming` attribute to start LIVE SELECTs. The property
+  raises `ConnectionError` if the client is not connected and
+  `StreamingError` if live queries are disabled on the connection.
+
 ## [1.5.3] - 2026-05-02
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.3"
+version = "1.5.4"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/cache/backends.py
+++ b/src/surql/cache/backends.py
@@ -266,7 +266,7 @@ class RedisCache(CacheBackend):
     if self._client is None:
       import redis.asyncio as redis
 
-      self._client = redis.from_url(self._url, decode_responses=True)  # type: ignore[no-untyped-call]
+      self._client = redis.from_url(self._url, decode_responses=True)
     return self._client
 
   def _make_key(self, key: str) -> str:

--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -4,9 +4,12 @@ import asyncio
 import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
+
+if TYPE_CHECKING:
+  from surql.connection.streaming import LiveQuery, StreamingManager
 from surrealdb import AsyncSurreal
 from surrealdb import RecordID as SdkRecordID
 from tenacity import (
@@ -181,6 +184,68 @@ class DatabaseClient:
   def is_connected(self) -> bool:
     """Check if client is currently connected."""
     return self._connected and self._client is not None
+
+  @property
+  def streaming(self) -> 'StreamingManager':
+    """Public accessor for the live-query streaming manager.
+
+    Returns:
+      The connection's :class:`StreamingManager`. Use this to start LIVE
+      SELECTs, subscribe to notifications, and kill queries.
+
+    Raises:
+      ConnectionError: If the client is not connected.
+      StreamingError: If live queries are disabled on this connection
+        (set ``enable_live_queries=True`` on :class:`ConnectionConfig`,
+        which requires a WebSocket or embedded engine URL).
+
+    Example:
+      ```python
+      query = await client.streaming.live('reading')
+      async for notification in client.streaming.subscribe(query):
+        ...
+      ```
+    """
+    if not self.is_connected:
+      raise ConnectionError('Client is not connected to database')
+    if self._streaming is None:
+      from surql.connection.streaming import StreamingError
+
+      raise StreamingError(
+        'Live queries are disabled. Set enable_live_queries=True on '
+        'ConnectionConfig and use a WebSocket or embedded engine URL.'
+      )
+    return self._streaming
+
+  async def live(self, table: str, diff: bool = False) -> 'LiveQuery':
+    """Start a LIVE SELECT on a table.
+
+    Convenience wrapper around ``client.streaming.live(table, diff=diff)``
+    so callers can subscribe to live changes without reaching into the
+    streaming manager directly.
+
+    Args:
+      table: Table name to watch.
+      diff: If True, notifications carry JSON-Patch diffs instead of full
+        records.
+
+    Returns:
+      A :class:`LiveQuery` handle. Pass it to ``client.streaming.subscribe``
+      to consume notifications, or ``client.streaming.kill`` to stop it.
+
+    Raises:
+      ConnectionError: If the client is not connected.
+      StreamingError: If live queries are disabled or the underlying
+        ``LIVE`` call fails.
+
+    Example:
+      ```python
+      query = await client.live('reading')
+      async for notification in client.streaming.subscribe(query):
+        ...
+      ```
+    """
+    return await self.streaming.live(table, diff=diff)
 
   async def connect(self) -> None:
     """Establish connection to the database with retry logic.

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,10 +1,12 @@
 """Tests for streaming module."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
 import pytest
 
+from surql.connection.client import ConnectionError, DatabaseClient
+from surql.connection.config import ConnectionConfig
 from surql.connection.streaming import LiveQuery, StreamingError, StreamingManager
 
 
@@ -399,3 +401,51 @@ class TestStreamingManager:
     assert query1.diff is False
     assert query2.diff is True
     assert len(streaming_manager.get_active_queries()) == 2
+
+
+class TestDatabaseClientStreamingPublicAPI:
+  """Tests for the public ``streaming`` property and ``live`` method on DatabaseClient."""
+
+  @pytest.fixture
+  def _config(self) -> ConnectionConfig:
+    return ConnectionConfig(_env_file=None, enable_live_queries=True)
+
+  @pytest.fixture
+  def _connected_client(self, _config: ConnectionConfig) -> DatabaseClient:
+    client = DatabaseClient(_config)
+    sdk = Mock()
+    sdk.live = AsyncMock(return_value=uuid4())
+    client._client = sdk
+    client._connected = True
+    client._streaming = StreamingManager(sdk)
+    return client
+
+  def test_streaming_property_raises_when_not_connected(self, _config: ConnectionConfig) -> None:
+    client = DatabaseClient(_config)
+    with pytest.raises(ConnectionError):
+      _ = client.streaming
+
+  def test_streaming_property_raises_when_disabled(self) -> None:
+    config = ConnectionConfig(_env_file=None, enable_live_queries=False)
+    client = DatabaseClient(config)
+    client._client = Mock()
+    client._connected = True
+    client._streaming = None
+    with pytest.raises(StreamingError, match='disabled'):
+      _ = client.streaming
+
+  def test_streaming_property_returns_manager(self, _connected_client: DatabaseClient) -> None:
+    assert isinstance(_connected_client.streaming, StreamingManager)
+
+  @pytest.mark.anyio
+  async def test_live_convenience_method(self, _connected_client: DatabaseClient) -> None:
+    query = await _connected_client.live('reading')
+    assert isinstance(query, LiveQuery)
+    assert query.table == 'reading'
+    _connected_client._client.live.assert_called_once_with('reading', diff=False)
+
+  @pytest.mark.anyio
+  async def test_live_convenience_method_diff(self, _connected_client: DatabaseClient) -> None:
+    query = await _connected_client.live('reading', diff=True)
+    assert query.diff is True
+    _connected_client._client.live.assert_called_once_with('reading', diff=True)

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.3"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Add a public `streaming` property and a `live(table, diff=False)` convenience
method on `DatabaseClient`, so callers can start LIVE SELECTs without reaching
into the private `_streaming` attribute.

Motivated by the tinytropolis gateway, which currently has this in `db.py`:

```python
if client._streaming is None:
    raise RuntimeError(...)
live = await client._streaming.live("reading")
```

After this PR, that becomes:

```python
live_query = await client.live("reading")
async for notification in client.streaming.subscribe(live_query):
    ...
```

The `streaming` property raises `ConnectionError` when not connected and
`StreamingError` when live queries are disabled on the `ConnectionConfig`,
so the failure mode is explicit instead of an opaque `AttributeError`.

Also drops a now-unused `# type: ignore[no-untyped-call]` on
`redis.from_url` so `mypy src` is clean (the redis 7.x stubs added a
type for it; pre-push hook surfaced this).

Bumps version to **1.5.4**.

## Test plan

- [x] `uv run pytest tests/test_streaming.py tests/test_connection.py --no-cov` (156 passed; 5 new in `TestDatabaseClientStreamingPublicAPI`)
- [x] `uv run mypy src` (clean, 80 files)
- [x] `uv run ruff check` and `uv run ruff format --check` (clean)
- [x] Pre-push hook passes