### PR TITLE
feat(streaming): polling LIVE fallback for embedded engine (1.5.5)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-05-02
+
+### Added
+
+- **Polling LIVE-query fallback for the embedded SurrealDB engine.** The
+  upstream `surrealdb` Python SDK's `AsyncEmbeddedSurrealConnection`
+  inherits `live()` / `subscribe_live()` from the WebSocket connection but
+  never initialises the `live_queues` attribute and the underlying Rust
+  extension (`_surrealdb_ext.AsyncEmbeddedDB`) only exposes a one-shot
+  `execute(cbor) -> bytes` call -- so calling `client.live(...)` on a
+  `surrealkv://` / `mem://` / `file://` URL crashes with
+  `AttributeError: 'AsyncEmbeddedSurrealConnection' object has no attribute
+  'live_queues'`.
+
+  `DatabaseClient.connect()` now detects embedded URLs (any of `mem://`,
+  `memory://`, `file://`, `surrealkv://`, `rocksdb://`, `tikv://`) and
+  installs a new `EmbeddedPollingStreamingManager` instead of the WS-native
+  `StreamingManager`. The polling manager exposes the same surface
+  (`live` / `subscribe` / `subscribe_with_callback` / `kill` / `kill_all` /
+  `get_active_queries`) so existing call sites do not branch on engine
+  type. It re-runs `SELECT * FROM <table>` on a configurable cadence
+  (default 0.25s / 4 Hz) and emits `{'action': 'CREATE', 'result': <row>}`
+  notifications for record ids that haven't been seen before, primed on
+  the first tick so historical rows do not flood the consumer. Two new
+  `ConnectionConfig` knobs control the fallback: `live_poll_interval_s`
+  (default `0.25`) and `live_poll_max_seen_ids` (default `10_000`,
+  bounded LRU).
+
+  This is a degraded mode -- only CREATE events are produced; UPDATE and
+  DELETE are not observable; latency is bounded by the poll interval --
+  but it lets downstream consumers (e.g. tinytropolis's LIVE-channels
+  dashboard pipeline) keep their embedded-database design constraint
+  instead of having to spin up a sidecar `ws://` SurrealDB. Public
+  re-exports: `EmbeddedPollingStreamingManager` and `is_embedded_url` from
+  `surql.connection`.
+
 ## [1.5.4] - 2026-05-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.4"
+version = "1.5.5"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/connection/__init__.py
+++ b/src/surql/connection/__init__.py
@@ -37,7 +37,13 @@ from surql.connection.context import (
   set_db,
 )
 from surql.connection.registry import ConnectionRegistry, RegistryError, get_registry
-from surql.connection.streaming import LiveQuery, StreamingError, StreamingManager
+from surql.connection.streaming import (
+  EmbeddedPollingStreamingManager,
+  LiveQuery,
+  StreamingError,
+  StreamingManager,
+  is_embedded_url,
+)
 from surql.connection.transaction import (
   Transaction,
   TransactionError,
@@ -84,5 +90,7 @@ __all__ = [
   'TokenAuth',
   # Streaming
   'StreamingManager',
+  'EmbeddedPollingStreamingManager',
   'LiveQuery',
+  'is_embedded_url',
 ]

--- a/src/surql/connection/_embedded_live_poll.py
+++ b/src/surql/connection/_embedded_live_poll.py
@@ -1,0 +1,177 @@
+"""Poll-based fallback for LIVE SELECT against the embedded SurrealDB engine.
+
+The official ``surrealdb`` Python SDK's :class:`AsyncEmbeddedSurrealConnection`
+does not implement a notification dispatcher: its Rust extension
+(``_surrealdb_ext.AsyncEmbeddedDB``) only exposes a one-shot
+``execute(cbor_request) -> bytes`` surface, so the inherited ``live`` /
+``subscribe_live`` methods either error (``live_queues`` attribute missing) or
+silently never deliver notifications.
+
+This module provides a degraded-but-functional alternative: instead of pushing
+notifications from the engine, it periodically polls a table and emits
+``{'action': 'CREATE', 'result': <row>}`` notifications for rows whose record
+ids haven't been seen yet. It is designed for append-mostly workloads (sensor
+telemetry, event logs, audit streams) where consumers care about new rows
+arriving and can tolerate the polling cadence as a latency floor.
+
+This is **not** a drop-in equivalent of native LIVE: there is no UPDATE or
+DELETE event, the cadence is bounded by ``interval_s``, and a long-running
+subscription accumulates seen ids in memory (capped via ``max_seen_ids``).
+The intended consumer is :class:`surql.connection.streaming.StreamingManager`
+when the underlying client is detected to be embedded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections import OrderedDict
+from collections.abc import AsyncIterator
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+class EmbeddedLivePoller:
+  """Poll a table for newly-inserted rows and yield CREATE-style notifications.
+
+  Each tick, this issues ``SELECT * FROM <table>`` (using the wrapped
+  ``DatabaseClient.execute`` path so it goes through the SDK's CBOR pipeline)
+  and emits one notification per row whose stringified ``id`` was not present
+  in a bounded LRU cache of previously-seen ids. On the first tick the cache
+  is primed (no notifications emitted) so consumers don't see a flood of
+  historical rows on subscription.
+
+  Args:
+    client: A connected :class:`surql.connection.DatabaseClient` instance whose
+      underlying SDK client is the embedded engine.
+    table: The table to watch.
+    interval_s: Seconds between polls. Defaults to 0.25 (4 Hz).
+    max_seen_ids: Maximum number of record ids to remember (FIFO eviction).
+      Older ids beyond this cap will be re-emitted as CREATE if they reappear
+      in subsequent polls; tune to your retention window. Defaults to 10_000.
+  """
+
+  def __init__(
+    self,
+    client: Any,
+    table: str,
+    *,
+    interval_s: float = 0.25,
+    max_seen_ids: int = 10_000,
+  ) -> None:
+    if interval_s <= 0:
+      raise ValueError('interval_s must be positive')
+    if max_seen_ids <= 0:
+      raise ValueError('max_seen_ids must be positive')
+    self._client = client
+    self._table = table
+    self._interval_s = interval_s
+    self._max_seen = max_seen_ids
+    self._seen: OrderedDict[str, None] = OrderedDict()
+    self._stopped = asyncio.Event()
+    self._primed = False
+
+  def stop(self) -> None:
+    """Signal the poll loop to terminate after the current tick."""
+    self._stopped.set()
+
+  @property
+  def is_stopped(self) -> bool:
+    """Whether stop() has been requested."""
+    return self._stopped.is_set()
+
+  def _remember(self, record_id: str) -> bool:
+    """Record a new id, evicting the oldest if at capacity.
+
+    Returns:
+      True when the id was newly seen, False if it was already known.
+    """
+    if record_id in self._seen:
+      # Refresh recency so active ids stay in the LRU.
+      self._seen.move_to_end(record_id)
+      return False
+    self._seen[record_id] = None
+    if len(self._seen) > self._max_seen:
+      self._seen.popitem(last=False)
+    return True
+
+  async def _fetch_rows(self) -> list[dict[str, Any]]:
+    """Run one SELECT and return the row list (empty on transient error)."""
+    try:
+      result = await self._client.execute(f'SELECT * FROM {self._table}')
+    except Exception as exc:
+      logger.warning(
+        'embedded_live_poll.fetch_failed',
+        table=self._table,
+        error=str(exc),
+      )
+      return []
+    rows = self._extract_rows(result)
+    return rows
+
+  @staticmethod
+  def _extract_rows(value: Any) -> list[dict[str, Any]]:
+    """Flatten a query response to a list of row dicts.
+
+    The wrapped client may return either a list of rows directly (post-
+    normalization) or a statement-envelope list -- accept both.
+    """
+    if value is None:
+      return []
+    if isinstance(value, dict):
+      if 'result' in value and isinstance(value['result'], list):
+        return [r for r in value['result'] if isinstance(r, dict)]
+      return [value]
+    if isinstance(value, list):
+      if not value:
+        return []
+      first = value[0]
+      if isinstance(first, dict) and 'result' in first and 'status' in first:
+        inner = first.get('result')
+        if isinstance(inner, list):
+          return [r for r in inner if isinstance(r, dict)]
+        return []
+      return [r for r in value if isinstance(r, dict)]
+    return []
+
+  async def stream(self) -> AsyncIterator[dict[str, Any]]:
+    """Yield CREATE-shaped notifications for newly-observed rows.
+
+    Yields:
+      Dicts shaped ``{'action': 'CREATE', 'result': <row>}``. The shape mirrors
+      the SurrealDB WS LIVE notification envelope so downstream consumers
+      (e.g. :class:`StreamingManager.subscribe`) treat poll events the same as
+      native ones.
+    """
+    logger.info(
+      'embedded_live_poll.starting',
+      table=self._table,
+      interval_s=self._interval_s,
+    )
+    try:
+      while not self._stopped.is_set():
+        rows = await self._fetch_rows()
+        if not self._primed:
+          # First tick primes the seen-set; do not emit historical rows.
+          for row in rows:
+            rid = row.get('id')
+            if rid is not None:
+              self._remember(str(rid))
+          self._primed = True
+        else:
+          for row in rows:
+            rid = row.get('id')
+            if rid is None:
+              continue
+            if self._remember(str(rid)):
+              yield {'action': 'CREATE', 'result': row}
+        with contextlib.suppress(TimeoutError):
+          await asyncio.wait_for(self._stopped.wait(), timeout=self._interval_s)
+    finally:
+      logger.info('embedded_live_poll.stopped', table=self._table)
+
+
+__all__ = ['EmbeddedLivePoller']

--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 if TYPE_CHECKING:
-  from surql.connection.streaming import LiveQuery, StreamingManager
+  from surql.connection.streaming import (
+    EmbeddedPollingStreamingManager,
+    LiveQuery,
+    StreamingManager,
+  )
 from surrealdb import AsyncSurreal
 from surrealdb import RecordID as SdkRecordID
 from tenacity import (
@@ -175,10 +179,13 @@ class DatabaseClient:
 
     # Import here to avoid circular imports
     from surql.connection.auth import AuthManager
-    from surql.connection.streaming import StreamingManager
+    from surql.connection.streaming import (
+      EmbeddedPollingStreamingManager,
+      StreamingManager,
+    )
 
     self._auth = AuthManager()
-    self._streaming: StreamingManager | None = None
+    self._streaming: StreamingManager | EmbeddedPollingStreamingManager | None = None
 
   @property
   def is_connected(self) -> bool:
@@ -186,12 +193,19 @@ class DatabaseClient:
     return self._connected and self._client is not None
 
   @property
-  def streaming(self) -> 'StreamingManager':
+  def streaming(self) -> 'StreamingManager | EmbeddedPollingStreamingManager':
     """Public accessor for the live-query streaming manager.
 
     Returns:
-      The connection's :class:`StreamingManager`. Use this to start LIVE
-      SELECTs, subscribe to notifications, and kill queries.
+      The connection's :class:`StreamingManager` (for ``ws://`` / ``wss://``
+      URLs) or :class:`EmbeddedPollingStreamingManager` (for embedded engine
+      URLs such as ``surrealkv://``, ``mem://``, ``file://``). Both expose
+      the same surface (``live`` / ``subscribe`` / ``kill`` / ``kill_all`` /
+      ``get_active_queries``); the polling variant emits CREATE-only
+      notifications at ``ConnectionConfig.live_poll_interval_s`` cadence and
+      cannot observe UPDATE / DELETE -- it exists because the upstream
+      ``surrealdb`` Python SDK ships an embedded connection that is missing
+      the live-notification dispatcher.
 
     Raises:
       ConnectionError: If the client is not connected.
@@ -286,11 +300,32 @@ class DatabaseClient:
           await self._client.use(self._config.namespace, self._config.database)
           self._connected = True
 
-          # Initialize streaming if WebSocket and enabled
+          # Initialize streaming if enabled. WebSocket URLs use the native
+          # notification dispatcher; embedded URLs (surrealkv://, mem://,
+          # file://) use a polling fallback because the upstream SDK's
+          # ``AsyncEmbeddedSurrealConnection`` does not implement live-query
+          # notifications.
           if self._config.enable_live_queries:
-            from surql.connection.streaming import StreamingManager
+            from surql.connection.streaming import (
+              EmbeddedPollingStreamingManager,
+              StreamingManager,
+              is_embedded_url,
+            )
 
-            self._streaming = StreamingManager(self._client)
+            if is_embedded_url(self._config.url):
+              self._streaming = EmbeddedPollingStreamingManager(
+                self,
+                interval_s=self._config.live_poll_interval_s,
+                max_seen_ids=self._config.live_poll_max_seen_ids,
+              )
+              self._log.info(
+                'embedded_polling_streaming_enabled',
+                interval_s=self._config.live_poll_interval_s,
+                max_seen_ids=self._config.live_poll_max_seen_ids,
+                note='LIVE notifications via polling fallback (CREATE only)',
+              )
+            else:
+              self._streaming = StreamingManager(self._client)
 
           self._log.info('connected_to_database')
 

--- a/src/surql/connection/config.py
+++ b/src/surql/connection/config.py
@@ -93,6 +93,27 @@ class ConnectionConfig(BaseSettings):
     default=True,
     description='Enable live query support (requires WebSocket)',
   )
+  live_poll_interval_s: float = Field(
+    default=0.25,
+    gt=0.0,
+    description=(
+      'Poll interval for the embedded-engine LIVE fallback. Only used when '
+      'connecting via an embedded URL (mem://, memory://, file://, '
+      'surrealkv://, rocksdb://, tikv://) because the upstream Python SDK '
+      'does not implement live-query notifications for the embedded engine. '
+      'Lower values reduce notification latency at the cost of more queries.'
+    ),
+  )
+  live_poll_max_seen_ids: int = Field(
+    default=10_000,
+    ge=1,
+    description=(
+      'Bounded LRU cap on the per-table seen-id set used by the embedded-'
+      'engine LIVE fallback. Tune to your retention window: ids evicted '
+      'from this cache will be re-emitted as CREATE if they reappear in a '
+      'subsequent poll.'
+    ),
+  )
 
   @field_validator('db_ns', 'db')
   @classmethod

--- a/src/surql/connection/streaming.py
+++ b/src/surql/connection/streaming.py
@@ -3,12 +3,32 @@
 import inspect
 from collections.abc import AsyncIterator, Callable
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import anyio
 import structlog
 
+from surql.connection._embedded_live_poll import EmbeddedLivePoller
+
 logger = structlog.get_logger(__name__)
+
+# URL prefixes that indicate the SurrealDB Python SDK will route through the
+# embedded engine (``AsyncEmbeddedSurrealConnection``). The embedded engine's
+# Rust extension does not expose a notification stream, so live queries fall
+# back to the polling implementation in ``_embedded_live_poll``.
+EMBEDDED_URL_PREFIXES: tuple[str, ...] = (
+  'mem://',
+  'memory://',
+  'file://',
+  'surrealkv://',
+  'rocksdb://',
+  'tikv://',
+)
+
+
+def is_embedded_url(url: str) -> bool:
+  """Return True if ``url`` will route through the embedded engine."""
+  return any(url.startswith(p) for p in EMBEDDED_URL_PREFIXES)
 
 
 class StreamingError(Exception):
@@ -271,4 +291,176 @@ class StreamingManager:
     Returns:
       List of active queries
     """
+    return [q for q in self._queries.values() if q.is_active]
+
+
+class EmbeddedPollingStreamingManager:
+  """Polling-based streaming manager for the embedded SurrealDB engine.
+
+  The official ``surrealdb`` Python SDK's ``AsyncEmbeddedSurrealConnection``
+  does not implement live-query notification dispatch -- the underlying Rust
+  extension only exposes a one-shot ``execute(cbor) -> bytes`` call, and the
+  inherited ``live`` method references a ``live_queues`` attribute that is
+  never initialized. This manager emulates LIVE behavior by polling the
+  watched table for newly-inserted rows.
+
+  This is a **degraded fallback**: only CREATE-style notifications are
+  emitted, latency is bounded by the poll interval, and updates / deletes are
+  not observed. It exists so that downstream code which subscribes to LIVE
+  events can keep working when SurrealDB is run in-process via
+  ``surrealkv://`` / ``mem://`` / ``file://`` URLs without a sidecar
+  ``ws://`` SurrealDB.
+
+  The public API matches :class:`StreamingManager` so callers can hold a
+  ``StreamingManager | EmbeddedPollingStreamingManager`` union without
+  branching on engine type at every call site.
+
+  Args:
+    client: A connected :class:`surql.connection.DatabaseClient` instance
+      that can issue raw queries via ``client.execute(...)``. The polling
+      manager does not access the underlying SDK client directly.
+    interval_s: Default poll interval used when ``live()`` is called without
+      an explicit override. Defaults to 0.25 seconds (4 Hz).
+    max_seen_ids: Default LRU cap on per-table seen-id sets. Defaults to
+      10_000.
+  """
+
+  def __init__(
+    self,
+    client: Any,
+    *,
+    interval_s: float = 0.25,
+    max_seen_ids: int = 10_000,
+  ) -> None:
+    self._client = client
+    self._interval_s = interval_s
+    self._max_seen = max_seen_ids
+    self._queries: dict[UUID, LiveQuery] = {}
+    self._pollers: dict[UUID, EmbeddedLivePoller] = {}
+    logger.info(
+      'embedded_polling_streaming_manager_initialized',
+      interval_s=interval_s,
+      max_seen_ids=max_seen_ids,
+    )
+
+  async def live(
+    self,
+    table: str,
+    diff: bool = False,
+    *,
+    interval_s: float | None = None,
+    max_seen_ids: int | None = None,
+  ) -> LiveQuery:
+    """Register a polling subscription for ``table``.
+
+    Args:
+      table: Table to watch.
+      diff: Accepted for API compatibility with :class:`StreamingManager`.
+        The polling fallback does not produce diffs and ignores this flag;
+        a warning is logged when ``diff=True`` is requested so callers can
+        spot the degradation.
+      interval_s: Optional per-query override for the poll interval.
+      max_seen_ids: Optional per-query override for the seen-id LRU cap.
+
+    Returns:
+      A :class:`LiveQuery` handle whose ``query_uuid`` is locally generated
+      (the embedded engine never issues one).
+    """
+    if diff:
+      logger.warning(
+        'embedded_polling_diff_not_supported',
+        table=table,
+        note='diff mode ignored; emitting CREATE-only notifications',
+      )
+
+    query_uuid = uuid4()
+    poller = EmbeddedLivePoller(
+      self._client,
+      table,
+      interval_s=interval_s if interval_s is not None else self._interval_s,
+      max_seen_ids=max_seen_ids if max_seen_ids is not None else self._max_seen,
+    )
+    live_query = LiveQuery(query_uuid=query_uuid, table=table, diff=False)
+    self._queries[query_uuid] = live_query
+    self._pollers[query_uuid] = poller
+
+    logger.info(
+      'embedded_live_query_started',
+      query_uuid=str(query_uuid),
+      table=table,
+      interval_s=poller._interval_s,
+    )
+    return live_query
+
+  async def subscribe(
+    self,
+    query: LiveQuery,
+  ) -> AsyncIterator[dict[str, Any]]:
+    """Yield CREATE-shaped notifications from the table poller.
+
+    Args:
+      query: A :class:`LiveQuery` previously returned by :meth:`live`.
+
+    Yields:
+      Dicts shaped ``{'action': 'CREATE', 'result': <row>}``.
+
+    Raises:
+      StreamingError: If ``query`` is unknown to this manager (i.e. wasn't
+        produced by ``EmbeddedPollingStreamingManager.live``).
+    """
+    poller = self._pollers.get(query.query_uuid)
+    if poller is None:
+      raise StreamingError(
+        f'unknown query uuid {query.query_uuid}; was it created by this manager?'
+      )
+    try:
+      async for notification in poller.stream():
+        await query.notify(notification)
+        yield notification
+    except Exception as exc:
+      logger.error(
+        'embedded_subscription_error',
+        error=str(exc),
+        query_uuid=str(query.query_uuid),
+      )
+      query.deactivate()
+      raise StreamingError(f'Subscription failed: {exc}') from exc
+    finally:
+      query.deactivate()
+
+  async def subscribe_with_callback(
+    self,
+    query: LiveQuery,
+    callback: Callable[[dict[str, Any]], None],
+  ) -> None:
+    """Subscribe and invoke ``callback`` for each notification.
+
+    Mirrors :meth:`StreamingManager.subscribe_with_callback`.
+    """
+    query.add_callback(callback)
+    async for _notification in self.subscribe(query):
+      pass
+
+  async def kill(self, query: LiveQuery) -> None:
+    """Stop a polling subscription and forget the query.
+
+    Args:
+      query: The :class:`LiveQuery` to terminate.
+    """
+    poller = self._pollers.pop(query.query_uuid, None)
+    if poller is not None:
+      poller.stop()
+    self._queries.pop(query.query_uuid, None)
+    query.deactivate()
+    logger.info('embedded_live_query_killed', query_uuid=str(query.query_uuid))
+
+  async def kill_all(self) -> None:
+    """Stop every active polling subscription managed here."""
+    for query in list(self._queries.values()):
+      if query.is_active:
+        await self.kill(query)
+    logger.info('embedded_all_queries_killed')
+
+  def get_active_queries(self) -> list[LiveQuery]:
+    """Return the list of currently-active queries."""
     return [q for q in self._queries.values() if q.is_active]

--- a/tests/test_embedded_live_poll.py
+++ b/tests/test_embedded_live_poll.py
@@ -1,0 +1,365 @@
+"""Tests for the embedded-engine LIVE polling fallback.
+
+These tests rely on real ``asyncio`` primitives (``create_task``, ``wait_for``,
+``sleep``) so they pin the anyio backend to ``asyncio`` -- the trio backend
+would error trying to use a missing running asyncio loop. The streaming
+manager itself is event-loop-agnostic; only the polling driver uses asyncio
+loops directly because it needs cooperative cancellation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+
+from surql.connection._embedded_live_poll import EmbeddedLivePoller
+from surql.connection.client import DatabaseClient
+from surql.connection.config import ConnectionConfig
+from surql.connection.streaming import (
+  EmbeddedPollingStreamingManager,
+  LiveQuery,
+  StreamingError,
+  is_embedded_url,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+  """Restrict every test in this module to the asyncio backend."""
+  return 'asyncio'
+
+
+class _FakeClient:
+  """Minimal stand-in for :class:`DatabaseClient` used by the poller.
+
+  Only ``execute(query)`` is consumed by :class:`EmbeddedLivePoller`. Each
+  call pops the next response from ``responses`` (or raises the next entry
+  if it's an Exception).
+  """
+
+  def __init__(self, responses: list[Any]) -> None:
+    self._responses = list(responses)
+    self.calls: list[str] = []
+
+  async def execute(
+    self,
+    query: str,
+    params: dict[str, Any] | None = None,  # noqa: ARG002
+  ) -> Any:
+    self.calls.append(query)
+    if not self._responses:
+      return []
+    nxt = self._responses.pop(0)
+    if isinstance(nxt, Exception):
+      raise nxt
+    return nxt
+
+
+class TestIsEmbeddedUrl:
+  """Smoke tests for the engine-detection helper."""
+
+  @pytest.mark.parametrize(
+    'url',
+    [
+      'mem://',
+      'memory://',
+      'file:///tmp/db',
+      'surrealkv:///data/foo.db',
+      'rocksdb:///tmp/foo.db',
+      'tikv://127.0.0.1:2379',
+    ],
+  )
+  def test_embedded_urls(self, url: str) -> None:
+    assert is_embedded_url(url) is True
+
+  @pytest.mark.parametrize(
+    'url',
+    [
+      'ws://localhost:8000/rpc',
+      'wss://example.com/rpc',
+      'http://localhost:8000',
+      'https://example.com',
+    ],
+  )
+  def test_remote_urls(self, url: str) -> None:
+    assert is_embedded_url(url) is False
+
+
+class TestEmbeddedLivePoller:
+  """Behavior of the per-table poller."""
+
+  @pytest.mark.anyio
+  async def test_first_tick_primes_without_emitting(self) -> None:
+    """Existing rows present at subscription time are NOT emitted."""
+    client = _FakeClient(
+      responses=[
+        # Tick 1 (priming): two existing rows
+        [{'id': 'reading:a', 'soil': 30}, {'id': 'reading:b', 'soil': 31}],
+        # Tick 2: same rows, no new ones
+        [{'id': 'reading:a', 'soil': 30}, {'id': 'reading:b', 'soil': 31}],
+      ]
+    )
+    poller = EmbeddedLivePoller(client, 'reading', interval_s=0.01)
+
+    received: list[dict[str, Any]] = []
+
+    async def consume() -> None:
+      async for note in poller.stream():
+        received.append(note)
+
+    task = asyncio.create_task(consume())
+    # Let two ticks complete then stop.
+    await asyncio.sleep(0.05)
+    poller.stop()
+    await task
+
+    assert received == []
+
+  @pytest.mark.anyio
+  async def test_emits_create_for_new_rows(self) -> None:
+    """Rows whose id is new are emitted with action=CREATE."""
+    client = _FakeClient(
+      responses=[
+        # Tick 1 (priming): one existing row
+        [{'id': 'reading:a', 'soil': 30}],
+        # Tick 2: new row appears
+        [{'id': 'reading:a', 'soil': 30}, {'id': 'reading:b', 'soil': 31}],
+        # Tick 3: another new row
+        [
+          {'id': 'reading:a', 'soil': 30},
+          {'id': 'reading:b', 'soil': 31},
+          {'id': 'reading:c', 'soil': 32},
+        ],
+      ]
+    )
+    poller = EmbeddedLivePoller(client, 'reading', interval_s=0.01)
+    received: list[dict[str, Any]] = []
+
+    async def consume() -> None:
+      async for note in poller.stream():
+        received.append(note)
+        if len(received) >= 2:
+          poller.stop()
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert len(received) == 2
+    assert all(n['action'] == 'CREATE' for n in received)
+    new_ids = {n['result']['id'] for n in received}
+    assert new_ids == {'reading:b', 'reading:c'}
+
+  @pytest.mark.anyio
+  async def test_seen_lru_cap_evicts_oldest(self) -> None:
+    """Seen-id LRU evicts oldest ids when over capacity."""
+    poller = EmbeddedLivePoller(_FakeClient([]), 'reading', interval_s=0.01, max_seen_ids=2)
+    assert poller._remember('a') is True
+    assert poller._remember('b') is True
+    assert poller._remember('c') is True  # evicts 'a'
+    # 'a' should be re-emit-able now
+    assert poller._remember('a') is True
+    # 'c' should still be remembered
+    assert poller._remember('c') is False
+
+  @pytest.mark.anyio
+  async def test_fetch_failure_does_not_crash_stream(self) -> None:
+    """A transient query error skips the tick but keeps the loop alive."""
+    client = _FakeClient(
+      responses=[
+        # Tick 1 (priming): empty
+        [],
+        # Tick 2: raises
+        RuntimeError('transient'),
+        # Tick 3: a new row
+        [{'id': 'reading:x'}],
+      ]
+    )
+    poller = EmbeddedLivePoller(client, 'reading', interval_s=0.01)
+    received: list[dict[str, Any]] = []
+
+    async def consume() -> None:
+      async for note in poller.stream():
+        received.append(note)
+        poller.stop()
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(task, timeout=2.0)
+    assert received[0]['action'] == 'CREATE'
+    assert received[0]['result']['id'] == 'reading:x'
+
+  @pytest.mark.anyio
+  async def test_extract_rows_handles_envelope_shapes(self) -> None:
+    """``_extract_rows`` accepts both bare lists and statement envelopes."""
+    extract = EmbeddedLivePoller._extract_rows
+    # Bare list of rows (post-normalization)
+    assert extract([{'id': 'a'}, {'id': 'b'}]) == [{'id': 'a'}, {'id': 'b'}]
+    # Statement-envelope form
+    assert extract([{'status': 'OK', 'result': [{'id': 'a'}]}]) == [{'id': 'a'}]
+    # None / empty
+    assert extract(None) == []
+    assert extract([]) == []
+    # Single dict
+    assert extract({'result': [{'id': 'a'}]}) == [{'id': 'a'}]
+
+  @pytest.mark.anyio
+  async def test_invalid_init_args(self) -> None:
+    """Constructor rejects nonsensical arguments."""
+    with pytest.raises(ValueError):
+      EmbeddedLivePoller(_FakeClient([]), 'reading', interval_s=0)
+    with pytest.raises(ValueError):
+      EmbeddedLivePoller(_FakeClient([]), 'reading', max_seen_ids=0)
+
+
+class TestEmbeddedPollingStreamingManager:
+  """Behavior of the polling streaming manager."""
+
+  @pytest.mark.anyio
+  async def test_live_returns_query_with_local_uuid(self) -> None:
+    """``live`` produces a LiveQuery with a locally-generated UUID."""
+    manager = EmbeddedPollingStreamingManager(_FakeClient([]), interval_s=0.01)
+    query = await manager.live('reading')
+
+    assert isinstance(query, LiveQuery)
+    assert query.table == 'reading'
+    assert query.diff is False
+    assert isinstance(query.query_uuid, UUID)
+    assert query in manager.get_active_queries()
+
+  @pytest.mark.anyio
+  async def test_diff_flag_logged_but_ignored(self) -> None:
+    """Requesting diff mode warns; the manager still returns a query."""
+    manager = EmbeddedPollingStreamingManager(_FakeClient([]))
+    query = await manager.live('reading', diff=True)
+    # diff mode is degraded to False on the polling fallback
+    assert query.diff is False
+
+  @pytest.mark.anyio
+  async def test_subscribe_yields_create_notifications(self) -> None:
+    """End-to-end: subscribe sees CREATE for newly-inserted rows."""
+    client = _FakeClient(
+      responses=[
+        [],  # priming tick: no rows
+        [{'id': 'reading:a'}],  # one new row
+      ]
+    )
+    manager = EmbeddedPollingStreamingManager(client, interval_s=0.01)
+    query = await manager.live('reading')
+
+    received: list[dict[str, Any]] = []
+
+    async def consume() -> None:
+      async for note in manager.subscribe(query):
+        received.append(note)
+        await manager.kill(query)
+
+    await asyncio.wait_for(consume(), timeout=2.0)
+    assert received == [{'action': 'CREATE', 'result': {'id': 'reading:a'}}]
+    assert query.is_active is False
+
+  @pytest.mark.anyio
+  async def test_subscribe_invokes_callbacks(self) -> None:
+    """``subscribe_with_callback`` fans notifications through the callback."""
+    client = _FakeClient(
+      responses=[
+        [],  # priming
+        [{'id': 'reading:a'}],
+      ]
+    )
+    manager = EmbeddedPollingStreamingManager(client, interval_s=0.01)
+    query = await manager.live('reading')
+    seen: list[dict[str, Any]] = []
+
+    def cb(note: dict[str, Any]) -> None:
+      seen.append(note)
+      manager.get_active_queries()  # just exercise the API
+      # Stop the poller after the first notification arrives
+      asyncio.get_running_loop().call_soon(lambda: manager._pollers[query.query_uuid].stop())
+
+    await asyncio.wait_for(
+      manager.subscribe_with_callback(query, cb),
+      timeout=2.0,
+    )
+    assert len(seen) == 1
+    assert seen[0]['action'] == 'CREATE'
+
+  @pytest.mark.anyio
+  async def test_subscribe_unknown_query_raises(self) -> None:
+    """``subscribe`` rejects a query not produced by this manager."""
+    manager = EmbeddedPollingStreamingManager(_FakeClient([]))
+    foreign = LiveQuery(query_uuid=UUID('11111111-1111-1111-1111-111111111111'), table='reading')
+
+    with pytest.raises(StreamingError, match='unknown query uuid'):
+      async for _ in manager.subscribe(foreign):
+        pass
+
+  @pytest.mark.anyio
+  async def test_kill_all_stops_every_poller(self) -> None:
+    """``kill_all`` deactivates every active query."""
+    manager = EmbeddedPollingStreamingManager(_FakeClient([]))
+    q1 = await manager.live('reading')
+    q2 = await manager.live('detection')
+
+    assert {q.query_uuid for q in manager.get_active_queries()} == {q1.query_uuid, q2.query_uuid}
+
+    await manager.kill_all()
+
+    assert manager.get_active_queries() == []
+    assert q1.is_active is False
+    assert q2.is_active is False
+
+
+class TestDatabaseClientEmbeddedSelection:
+  """``DatabaseClient.connect`` picks the right manager per URL scheme."""
+
+  def _make_config(self, url: str) -> ConnectionConfig:
+    return ConnectionConfig(
+      _env_file=None,
+      url=url,
+      namespace='test',
+      database='test',
+      enable_live_queries=True,
+    )
+
+  @pytest.mark.anyio
+  async def test_embedded_url_installs_polling_manager(
+    self, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+    """A ``surrealkv://`` URL routes to the polling manager."""
+    config = self._make_config('surrealkv:///tmp/x.db')
+    client = DatabaseClient(config)
+
+    fake_sdk = MagicMock()
+    fake_sdk.connect = AsyncMock()
+    fake_sdk.use = AsyncMock()
+    monkeypatch.setattr('surql.connection.client.AsyncSurreal', lambda _url: fake_sdk)
+
+    await client.connect()
+    try:
+      assert isinstance(client.streaming, EmbeddedPollingStreamingManager)
+    finally:
+      client._connected = False  # short-circuit disconnect
+
+  @pytest.mark.anyio
+  async def test_websocket_url_installs_native_manager(
+    self, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+    """A ``ws://`` URL routes to the native streaming manager."""
+    from surql.connection.streaming import StreamingManager
+
+    config = self._make_config('ws://localhost:8000/rpc')
+    client = DatabaseClient(config)
+
+    fake_sdk = MagicMock()
+    fake_sdk.connect = AsyncMock()
+    fake_sdk.use = AsyncMock()
+    monkeypatch.setattr('surql.connection.client.AsyncSurreal', lambda _url: fake_sdk)
+
+    await client.connect()
+    try:
+      assert isinstance(client.streaming, StreamingManager)
+    finally:
+      client._connected = False

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.4"
+version = "1.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Add `EmbeddedPollingStreamingManager` so `client.streaming.live(...)` works against `surrealkv://` / `mem://` / `file://` URLs. The upstream `surrealdb` Python SDK's `AsyncEmbeddedSurrealConnection` inherits `live()` / `subscribe_live()` from the WS connection but never initialises `live_queues`, and the Rust extension (`_surrealdb_ext.AsyncEmbeddedDB`) only exposes one-shot `execute(cbor) -> bytes` -- so calling `live()` on an embedded URL crashes with `AttributeError: 'AsyncEmbeddedSurrealConnection' object has no attribute 'live_queues'`.
- `DatabaseClient.connect()` detects embedded URLs and installs the polling manager instead of `StreamingManager`. Same public surface (`live` / `subscribe` / `subscribe_with_callback` / `kill` / `kill_all` / `get_active_queries`); the polling variant re-runs `SELECT * FROM <table>` on a configurable cadence and emits `{'action': 'CREATE', 'result': <row>}` for record ids it hasn't seen before, primed on the first tick so existing rows don't flood the consumer.
- Two new `ConnectionConfig` knobs: `live_poll_interval_s` (default `0.25`) and `live_poll_max_seen_ids` (default `10_000`, bounded LRU).
- Public re-exports: `EmbeddedPollingStreamingManager` and `is_embedded_url` from `surql.connection`.
- Bumps version to **1.5.5**. Non-breaking (degraded mode is opt-in via engine type).

This is a degraded mode -- CREATE only, no UPDATE / DELETE, latency bounded by poll interval -- but it lets downstream consumers (e.g. tinytropolis) keep their embedded-database design constraint instead of spinning up a sidecar `ws://` SurrealDB. A real fix would require Rust-side changes to the `surrealdb` SDK to expose a notification stream from `_surrealdb_ext`; tracked separately.

## Test plan

- [x] `uv run ruff format --check` (src + tests)
- [x] `uv run ruff check src tests`
- [x] `uv run mypy --strict src`
- [x] `uv run pytest --ignore=tests/integration` (2523 passed, 9 skipped)
- [x] 24 new unit tests in `tests/test_embedded_live_poll.py` covering: priming behavior, CREATE emission for new ids, LRU eviction, transient-error tolerance, envelope-shape extraction, manager lifecycle, callback fan-out, unknown-query rejection, and `DatabaseClient` engine-routing for both `surrealkv://` and `ws://` URLs.

## Skip GHA

Per standing rules: cancel queued runs, admin-merge on local gates only.