### PR TITLE
fix(migration): use type::thing(table, id) for record-id construction (1.5.6)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.6] - 2026-05-02
+
+### Fixed
+
+- **Migration runner / record-id construction (`type::record` vs
+  `type::thing`).** `record_migration` and `DatabaseClient.select('table:id')`
+  were emitting `type::record($table, $id)` to construct a record id, but
+  in SurrealDB v3 the two-arg form of `type::record(value, type)` is a
+  *type coercion* (cast `value` into `record<type>`), NOT a table+id
+  constructor. Calling `type::record('_migration_history', '0001_init')`
+  is interpreted as "coerce `'_migration_history'` into
+  `record<0001_init>`" and fails with `Expected a record<0001_init> but
+  cannot convert '_migration_history' into a record<0001_init>`. Replaced
+  both call sites with `type::thing($table, $id)`, which is the actual
+  record-id constructor. This blocked any downstream consumer from running
+  migrations with surql-py 1.5.0--1.5.5.
+- The `RecordRef` / `record_ref()` and `type_record()` Python helpers also
+  rendered `type::record('table', id)` -- they now emit
+  `type::thing('table', id)`. The Python function names are preserved for
+  source compatibility (`type_record` is now an alias for `type_thing`).
+- Updated `docs/v3-patterns.md`, `docs/migration.md`, `docs/query-ux.md`,
+  `docs/api/index.md`, and `README.md` to reflect that `type::thing` is
+  the constructor on both v2 and v3 (correcting the earlier claim that
+  v3 renamed `type::thing` to `type::record`).
+- Added `tests/test_migration_history.py::TestRecordMigrationAgainstEmbeddedDb`
+  which round-trips `record_migration` through an embedded `mem://`
+  SurrealDB so future regressions of this kind are caught locally without
+  a Docker container.
+
 ## [1.5.5] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 
 - **Code-First Migrations** - Schema changes defined in code with automatic migration generation
 - **Type-Safe Query Builder** - Composable queries with Pydantic model integration
-- **SurrealDB v3 Ready** - Emits v3-correct SurrealQL (datetime casts, `count() GROUP ALL`, `type::record`, buffered transactions, idempotent DDL)
+- **SurrealDB v3 Ready** - Emits v3-correct SurrealQL (datetime casts, `count() GROUP ALL`, `type::thing(table, id)` record-id construction, buffered transactions, idempotent DDL)
 - **Query UX Helpers** - First-class wrappers for `time::now`, `math::*`, `string::*`, `count_if`, `type_record`, and typed aggregations -- no raw SurrealQL required
 - **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
 - **Graph Traversal** - Native SurrealDB graph features with edge relationships
@@ -93,7 +93,7 @@ rows = await aggregate_records(
 
 # Record-ID construction without string concatenation
 ref = type_record('user', 'alice').to_surql()
-# -> type::record('user', 'alice')
+# -> type::thing('user', 'alice')
 ```
 
 ### Deploy across environments

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -501,8 +501,8 @@ Raw SurrealQL function-call wrapper that renders verbatim when used as a value.
 **Key Functions:**
 
 - `surql_fn(name, *args)` - Build a `SurrealFn` from a function name and arguments
-- `type_record(table, id)` - Build `type::record('table', id)` (v3-preferred form)
-- `type_thing(table, id)` - Build `type::thing('table', id)` (v2-compatible alias)
+- `type_record(table, id)` - Build a `type::thing('table', id)` record-id (the helper is named `type_record` for source compatibility but emits `type::thing`)
+- `type_thing(table, id)` - Build `type::thing('table', id)` (canonical name)
 
 See [Query UX Helpers](../query-ux.md#type_record-type_thing) for composition examples.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -92,7 +92,7 @@ Additive at the Python API level. The SurrealQL emitted by the library changed t
 - **Datetime cast on `_migration_history`**: `record_migration()` now writes `applied_at = <datetime> $applied_at`.
 - **Buffered `BEGIN`/`COMMIT`**: `DatabaseClient.execute()` batches transaction-scoped statements into a single RPC frame so v3 honours the commit.
 - **`GROUP ALL` on `count_records`**: `count_records()` now appends `GROUP ALL` so v3 accepts the aggregate. The helper still accepts both the envelope shape and a bare scalar list from the SDK.
-- **`type::record` over `type::thing`**: select record-ID targets route through `type::record(...)` on v3. `type_record` is now preferred over `type_thing` in new code.
+- **`type::thing` constructor**: select record-ID targets and the migration history writer route through `type::thing(table, id)` on v3. (1.5.0--1.5.5 mistakenly emitted `type::record(table, id)`, but that's a type coercion in v3, not a constructor.) The Python helper `type_record(...)` is kept as an alias and now produces `type::thing(...)`.
 - **Idempotent DDL**: `DEFINE TABLE _migration_history IF NOT EXISTS` (and the `if_not_exists` flag across the schema generator) so `surql migrate up` is safe to re-run.
 - **Graph depth unrolling**: `traverse(...)` unrolls `{min..max}` depth ranges into literal hop unions that v3 accepts.
 - **SDK pin**: minimum `surrealdb` SDK bumped to v2.0.0a1, which speaks v3's RPC protocol.
@@ -104,7 +104,7 @@ Nothing is required to keep 1.3.x code running. If you hand-write SurrealQL anyw
 
 - Replace `count(*)` with `count()` and add `GROUP ALL` to any full-table aggregate. See [v3 patterns: count() aggregates](v3-patterns.md#count-aggregates-require-group-all).
 - Cast datetime literals explicitly: `<datetime> $value` or `<datetime> '2026-...'`. See [v3 patterns: datetime cast](v3-patterns.md#datetime-cast-on-insert).
-- Prefer `type::record('table', id)` over `type::thing('table', id)` for new expressions. See [v3 patterns: record-ID construction](v3-patterns.md#record-id-construction-typerecord-not-typething).
+- Use `type::thing('table', id)` for record-id construction (and prefer `type_thing(...)` / `type_record(...)` helpers). See [v3 patterns: record-ID construction](v3-patterns.md#record-id-construction-typething-table-id).
 - Ensure `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` is issued in a single `client.execute(...)` call, or use the `transaction()` context manager which already does so.
 
 ## 1.3.1 -- embedded migration fix

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -6,38 +6,38 @@ Every example below shows the raw SurrealQL you used to have to write and the ty
 
 ## Why bother?
 
-- **Correctness under v3** — `type::record` vs `type::thing`, `count()` vs `count(*)`, explicit `<datetime>` casts, and `GROUP ALL` are all easy to forget. The helpers emit the correct form by default.
+- **Correctness under v3** — `type::thing` (constructor) vs `type::record` (type coercion), `count()` vs `count(*)`, explicit `<datetime>` casts, and `GROUP ALL` are all easy to forget. The helpers emit the correct form by default.
 - **Composability** — helpers return `SurrealFn` instances, so they slot into `Query.select([...])`, `Query.set(**kwargs)`, `aggregate_records(select={...})`, and `client.execute(params=...)` without double-escaping.
 - **Refactorability** — renaming a field no longer means a grep across string-concatenated SurrealQL; the helpers take parameters, not literals.
 
 ## `type_record` / `type_thing`
 
-Build `type::record('table', id)` / `type::thing('table', id)` expressions without string concatenation.
+Build `type::thing('table', id)` record-id expressions without string concatenation. Both `type_record` and `type_thing` Python helpers emit `type::thing(...)`; `type_record` is kept as a source-compat alias because earlier versions of this library mistakenly emitted `type::record(table, id)` -- which in SurrealDB v3 is a type-coercion call (`cast 'table' into record<id>`), not a constructor, and fails at runtime.
 
 ```python
 from surql import type_record, type_thing, RecordID
 
 # Before
-raw = "type::record('user', 'alice')"
+raw = "type::thing('user', 'alice')"
 
 # After
 type_record('user', 'alice').to_surql()
-# -> "type::record('user', 'alice')"
+# -> "type::thing('user', 'alice')"
 
 # Integers render unquoted
 type_record('post', 42).to_surql()
-# -> "type::record('post', 42)"
+# -> "type::thing('post', 42)"
 
 # RecordID and SurrealFn arguments render verbatim (no double-quoting)
 type_record('edge', RecordID(table='user', id='alice')).to_surql()
-# -> "type::record('edge', user:alice)"
+# -> "type::thing('edge', user:alice)"
 
-# Legacy v2 form, still accepted by v3
+# Canonical name; identical output
 type_thing('user', 'alice').to_surql()
 # -> "type::thing('user', 'alice')"
 ```
 
-Prefer `type_record` for new code (see [v3 patterns](v3-patterns.md#record-id-construction-typerecord-not-typething)); `type_thing` exists for callers that still target v2 servers.
+Both forms emit the same SurrealQL; pick whichever name reads better in your code (see [v3 patterns](v3-patterns.md#record-id-construction-typething-table-id)).
 
 ## Function factories (`SurrealFn`)
 

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -69,20 +69,23 @@ await count_records('user')  # -> SELECT count() AS count FROM user GROUP ALL
 
 `count_if(predicate)` renders `count(<predicate>)` for conditional counts (see [Query UX helpers](query-ux.md#count_if)).
 
-## Record-ID construction: `type::record`, not `type::thing`
+## Record-ID construction: `type::thing(table, id)`
 
-`type::thing('table', 'id')` was renamed to `type::record('table', 'id')` in v3. The `type::thing` name still resolves for backwards compatibility but new code should use `type::record` directly.
+The constructor for a record id from a separate table name and id value is `type::thing(table, id)` on both SurrealDB v2 and v3.
+
+> [!WARNING]
+> Earlier versions of this guide claimed `type::thing` was renamed to `type::record` in v3. That was wrong. In v3 the **two-arg** form of `type::record(value, type)` is a *type coercion* -- it casts `value` into `record<type>`, and `type::record('user', 'alice')` is interpreted as "coerce 'user' into `record<alice>`" (which fails). The single-arg form `type::record('user:alice')` parses a full record-id string. For table+id construction, use `type::thing(table, id)`.
 
 **Prefer:**
 
 ```python
-from surql import type_record
+from surql import type_record  # alias kept for source compatibility
 
 ref = type_record('user', 'alice').to_surql()
-# -> type::record('user', 'alice')
+# -> type::thing('user', 'alice')
 ```
 
-`type_thing()` is still exported for code that must target older servers, and generates the exact v2 form:
+`type_thing()` is the canonical name and is identical:
 
 ```python
 from surql import type_thing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.5"
+version = "1.5.6"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.1'
+__version__ = '1.5.6'
 
 __all__ = [
   # Configuration

--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -411,8 +411,13 @@ class DatabaseClient:
     ``db.select`` is interpreted as a table name containing a colon
     (and silently returns nothing). When the target matches the
     record-id pattern we dispatch via raw SurrealQL
-    ``SELECT * FROM type::record($table, $id)`` so the server treats it
+    ``SELECT * FROM type::thing($table, $id)`` so the server treats it
     as a specific record. Mirrors the TS / rs / go ports.
+
+    Note: this used to call ``type::record($table, $id)``, but in v3 the
+    two-arg form of ``type::record(value, type)`` is a *type coercion*
+    (cast ``value`` into ``record<type>``), NOT a table+id constructor;
+    the constructor is ``type::thing(table, id)``.
 
     Args:
       target: Target table or record ID
@@ -434,7 +439,7 @@ class DatabaseClient:
         if _is_record_id_target(target):
           table, id_part = target.split(':', 1)
           raw = await self._client.query(
-            'SELECT * FROM type::record($table, $id)',
+            'SELECT * FROM type::thing($table, $id)',
             {'table': table, 'id': id_part},
           )
           rows = _extract_select_rows(_normalize_sdk_value(raw))

--- a/src/surql/migration/history.py
+++ b/src/surql/migration/history.py
@@ -32,7 +32,7 @@ def _record_id_for(version: str) -> str:
   """Sanitize a migration version into a safe SurrealDB record id.
 
   SurrealDB record ids must be alphanumeric/underscore (or bracketed).
-  Replace anything else with ``_`` so ``type::record($table, $id)``
+  Replace anything else with ``_`` so ``type::thing($table, $id)``
   accepts the value without extra quoting.
 
   Args:
@@ -197,7 +197,16 @@ async def record_migration(
       params['execution_time_ms'] = execution_time_ms
       set_clauses.append('execution_time_ms = $execution_time_ms')
 
-    statement = f'CREATE type::record($table, $id) SET {", ".join(set_clauses)};'
+    # Use `type::thing(table, id)` (not `type::record`). In SurrealDB v3,
+    # `type::record(value, type)` with two args is a runtime type-check that
+    # coerces `value` into a `record<type>` -- it's NOT a table+id record-id
+    # constructor. Calling `type::record('_migration_history', '0001_init')`
+    # is interpreted as "coerce '_migration_history' into record<0001_init>"
+    # and fails with `Expected a record<0001_init> but cannot convert
+    # '_migration_history' into a record<0001_init>`. The correct constructor
+    # is `type::thing(table, id)`, which takes a table name + id and returns
+    # a record id of that table.
+    statement = f'CREATE type::thing($table, $id) SET {", ".join(set_clauses)};'
     await client.execute(statement, params)
 
     log.info('migration_recorded', version=version)

--- a/src/surql/types/record_ref.py
+++ b/src/surql/types/record_ref.py
@@ -1,27 +1,34 @@
-"""Record reference helper for SurrealDB type::record() calls.
+"""Record reference helper for SurrealDB ``type::thing()`` calls.
 
-This module provides a wrapper that generates type::record() expressions
+This module provides a wrapper that generates ``type::thing()`` expressions
 for referencing records by table and ID in parameterized queries.
+
+Note: previously this rendered ``type::record('table', 'id')``. In SurrealDB
+v3 the two-arg form of ``type::record(value, type)`` is a *type coercion*
+(cast ``value`` into ``record<type>``), NOT a table+id constructor -- so the
+old rendering produced ``Expected a record<id> but cannot convert 'table'
+into a record<id>`` errors. The correct constructor is
+``type::thing(table, id)`` and that's what we emit now.
 """
 
 from pydantic import BaseModel, ConfigDict
 
 
 class RecordRef(BaseModel):
-  """Reference to a SurrealDB record via type::record().
+  """Reference to a SurrealDB record via ``type::thing()``.
 
-  Generates a type::record() call that resolves to a record ID at query time.
-  When used as a field value in CREATE/UPDATE/UPSERT operations, the
+  Generates a ``type::thing()`` call that resolves to a record ID at query
+  time. When used as a field value in CREATE/UPDATE/UPSERT operations, the
   expression renders as raw SurrealQL rather than a quoted string.
 
   Examples:
     >>> ref = RecordRef(table='user', record_id='alice')
     >>> ref.to_surql()
-    "type::record('user', 'alice')"
+    "type::thing('user', 'alice')"
 
     >>> ref = RecordRef(table='post', record_id=123)
     >>> ref.to_surql()
-    "type::record('post', 123)"
+    "type::thing('post', 123)"
   """
 
   table: str
@@ -30,30 +37,30 @@ class RecordRef(BaseModel):
   model_config = ConfigDict(frozen=True)
 
   def to_surql(self) -> str:
-    """Render as a type::record() SurrealQL expression.
+    """Render as a ``type::thing()`` SurrealQL expression.
 
     Returns:
-      SurrealQL type::record() expression
+      SurrealQL ``type::thing()`` expression
     """
     if isinstance(self.record_id, int):
-      return f"type::record('{self.table}', {self.record_id})"
+      return f"type::thing('{self.table}', {self.record_id})"
     # Escape single quotes in the record_id string
     escaped_id = self.record_id.replace('\\', '\\\\').replace("'", "\\'")
-    return f"type::record('{self.table}', '{escaped_id}')"
+    return f"type::thing('{self.table}', '{escaped_id}')"
 
   def __str__(self) -> str:
     """Return string representation.
 
     Returns:
-      SurrealQL type::record() expression
+      SurrealQL ``type::thing()`` expression
     """
     return self.to_surql()
 
 
 def record_ref(table: str, record_id: str | int) -> RecordRef:
-  """Create a SurrealDB type::record() reference.
+  """Create a SurrealDB ``type::thing()`` reference.
 
-  Generates a type::record() expression that can be used as a field value
+  Generates a ``type::thing()`` expression that can be used as a field value
   in CREATE/UPDATE/UPSERT operations. The expression is emitted as raw
   SurrealQL rather than a quoted string.
 
@@ -66,9 +73,9 @@ def record_ref(table: str, record_id: str | int) -> RecordRef:
 
   Examples:
     >>> record_ref('user', 'alice').to_surql()
-    "type::record('user', 'alice')"
+    "type::thing('user', 'alice')"
 
     >>> record_ref('post', 123).to_surql()
-    "type::record('post', 123)"
+    "type::thing('post', 123)"
   """
   return RecordRef(table=table, record_id=record_id)

--- a/src/surql/types/surreal_fn.py
+++ b/src/surql/types/surreal_fn.py
@@ -81,7 +81,7 @@ def surql_fn(name: str, *args: Any) -> SurrealFn:
 
 
 def _render_record_id_arg(record_id: Any) -> str:
-  """Render a record_id argument for type::record / type::thing calls.
+  """Render a record_id argument for ``type::thing`` calls.
 
   - ``RecordID`` instances render via their ``to_surql()`` form.
   - ``SurrealFn`` values render verbatim (so nested function calls compose).
@@ -112,7 +112,17 @@ def _render_record_id_arg(record_id: Any) -> str:
 
 
 def type_record(table: str, record_id: Any) -> SurrealFn:
-  """Build a ``type::record('table', id)`` SurrealDB function call.
+  """Build a ``type::thing('table', id)`` SurrealDB function call.
+
+  Note: previously this emitted ``type::record('table', id)``, but in
+  SurrealDB v3 the two-arg form of ``type::record(value, type)`` is a *type
+  coercion* (cast ``value`` into ``record<type>``), NOT a table+id
+  constructor. Calling ``type::record('task', 'abc')`` is interpreted as
+  "coerce 'task' into ``record<abc>``" and fails. The correct constructor
+  is ``type::thing(table, id)``, which is what we emit now. The Python
+  helper is still named ``type_record`` for source compatibility, but the
+  SurrealQL it produces is ``type::thing(...)`` -- :func:`type_thing` is
+  a thin alias that produces the same output.
 
   Produces a :class:`SurrealFn` that renders as raw SurrealQL, so it
   composes with query builders and raw queries just like :func:`surql_fn`.
@@ -124,26 +134,25 @@ def type_record(table: str, record_id: Any) -> SurrealFn:
       :class:`SurrealFn` values render verbatim.
 
   Returns:
-    ``SurrealFn`` wrapping a ``type::record('table', id)`` expression.
+    ``SurrealFn`` wrapping a ``type::thing('table', id)`` expression.
 
   Examples:
     >>> type_record('task', 'abc').to_surql()
-    "type::record('task', 'abc')"
+    "type::thing('task', 'abc')"
 
     >>> type_record('post', 42).to_surql()
-    "type::record('post', 42)"
+    "type::thing('post', 42)"
   """
   arg = _render_record_id_arg(record_id)
-  return SurrealFn(expression=f"type::record('{table}', {arg})")
+  return SurrealFn(expression=f"type::thing('{table}', {arg})")
 
 
 def type_thing(table: str, record_id: Any) -> SurrealFn:
-  """Build a ``type::thing('table', id)`` SurrealDB function call (v2 form).
+  """Build a ``type::thing('table', id)`` SurrealDB function call.
 
-  ``type::thing`` is the legacy/alternate form for constructing record IDs
-  in SurrealDB v2; it behaves the same as :func:`type_record` at the API
-  level but renders the ``type::thing`` function name, which is still
-  accepted by SurrealDB v3 for backwards compatibility.
+  ``type::thing(table, id)`` is the SurrealQL constructor for record IDs
+  in both v2 and v3. This is now an alias for :func:`type_record`, which
+  also emits ``type::thing(...)``.
 
   Args:
     table: Target table name.

--- a/tests/integration/test_query_ux.py
+++ b/tests/integration/test_query_ux.py
@@ -3,7 +3,7 @@
 Exercises behavior that only matters against a live ``surrealdb:v3.0.5``
 container:
 
-- ``type::record(...)`` rendered through the builder still round-trips
+- ``type::thing(...)`` rendered through the builder still round-trips
   against v3 (sub-feature #1).
 - ``aggregate_records`` executes GROUP BY / GROUP ALL queries and unwraps
   the response envelope (sub-feature #4).
@@ -24,13 +24,15 @@ from surql.types.surreal_fn import type_record
 
 
 class TestTypeRecordV3:
-  """type::record(...) must still round-trip through the builder on v3."""
+  """``type_record`` (which emits ``type::thing(...)``) must still
+  round-trip through the builder on v3."""
 
   @pytest.mark.anyio
   async def test_insert_with_type_record_reference(
     self, integration_client: DatabaseClient
   ) -> None:
-    """Insert a comment that references a user via ``type::record()``."""
+    """Insert a comment that references a user via ``type_record`` (which
+    emits ``type::thing(...)`` underneath)."""
     await integration_client.execute('DEFINE TABLE ux_user SCHEMALESS;')
     await integration_client.execute('DEFINE TABLE ux_comment SCHEMALESS;')
     await integration_client.execute("CREATE ux_user:alice SET name = 'Alice'")

--- a/tests/integration/test_v3_happy_path.py
+++ b/tests/integration/test_v3_happy_path.py
@@ -8,7 +8,7 @@ Exercises every v3-correctness fix from the release/1.4.0 campaign:
 - #13: transactions flush as a single batched RPC
 - #14: ``count_records`` aggregates via ``GROUP ALL``
 - #15: ``get_record`` / ``db.select('table:id')`` resolves the
-       record via ``type::record``
+       record via ``type::thing``
 - #16: ``DEFINE TABLE`` / ``DEFINE FIELD`` / ``DEFINE INDEX`` are
        idempotent on re-run
 - #17: table-missing probe does not swallow unrelated errors
@@ -173,12 +173,12 @@ class TestCountRecordsV3:
 
 
 # ---------------------------------------------------------------------------
-# db.select("table:id") via type::record (#15)
+# db.select("table:id") via type::thing (#15)
 # ---------------------------------------------------------------------------
 
 
 class TestRecordIdSelectV3:
-  """Bug #15: bare `table:id` string -> raw type::record SQL."""
+  """Bug #15: bare `table:id` string -> raw type::thing SQL."""
 
   @pytest.mark.anyio
   async def test_get_record_resolves_record_id(self, integration_client: DatabaseClient) -> None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -383,17 +383,21 @@ class TestDatabaseClient:
     mock_db_client._client.select.assert_called_once_with('user')
 
   @pytest.mark.anyio
-  async def test_select_record_id_uses_type_record_query(
+  async def test_select_record_id_uses_type_thing_query(
     self, mock_db_client: DatabaseClient
   ) -> None:
     """Regression (bug #15): `"table:id"` targets must route through
-    `SELECT * FROM type::record($table, $id)`.
+    `SELECT * FROM type::thing($table, $id)`.
 
     On SurrealDB v3, passing a bare ``"user:alice"`` string to
     ``db.select`` is interpreted as a table name containing a colon
     and returns nothing. The client must detect record-id-shaped
     targets and dispatch via raw SurrealQL so the server treats them
     as record ids. TS / rs / go ports all do this.
+
+    Must use ``type::thing(table, id)`` (not ``type::record(table, id)``):
+    in v3 the two-arg form of ``type::record`` is a type coercion, not a
+    constructor.
     """
     mock_db_client._client.query = AsyncMock(return_value=[{'id': 'user:alice', 'name': 'Alice'}])
 
@@ -402,10 +406,10 @@ class TestDatabaseClient:
     # Must NOT go through the SDK's bare string `select` path.
     mock_db_client._client.select.assert_not_called()
 
-    # Must hit `query` with `type::record($table, $id)` and bound params.
+    # Must hit `query` with `type::thing($table, $id)` and bound params.
     mock_db_client._client.query.assert_called_once()
     sql, params = mock_db_client._client.query.call_args.args
-    assert 'type::record($table, $id)' in sql
+    assert 'type::thing($table, $id)' in sql
     assert params == {'table': 'user', 'id': 'alice'}
 
     # Single-record unwrap still yields a dict (not a list).

--- a/tests/test_features_1_4.py
+++ b/tests/test_features_1_4.py
@@ -1,7 +1,7 @@
 """Tests for features #1-#4: aggregation, record_ref, surql_fn, result extraction.
 
 Issue #1: GROUP BY / GROUP ALL aggregation support
-Issue #2: type::record() helper
+Issue #2: type::thing() helper
 Issue #3: time::now() / SurrealDB function support
 Issue #4: Result extraction helpers
 """
@@ -229,7 +229,7 @@ class TestAggregationExpressionComposition:
 
 
 # =============================================================================
-# Issue #2: type::record() helper
+# Issue #2: type::thing() helper
 # =============================================================================
 
 
@@ -239,12 +239,12 @@ class TestRecordRef:
   def test_record_ref_string_id(self) -> None:
     """Test RecordRef with string ID."""
     ref = RecordRef(table='user', record_id='alice')
-    assert ref.to_surql() == "type::record('user', 'alice')"
+    assert ref.to_surql() == "type::thing('user', 'alice')"
 
   def test_record_ref_int_id(self) -> None:
     """Test RecordRef with integer ID."""
     ref = RecordRef(table='post', record_id=123)
-    assert ref.to_surql() == "type::record('post', 123)"
+    assert ref.to_surql() == "type::thing('post', 123)"
 
   def test_record_ref_str_method(self) -> None:
     """Test RecordRef __str__ matches to_surql."""
@@ -277,13 +277,13 @@ class TestRecordRefFunction:
     """Test record_ref() helper with string ID."""
     ref = record_ref('user', 'alice')
     assert isinstance(ref, RecordRef)
-    assert ref.to_surql() == "type::record('user', 'alice')"
+    assert ref.to_surql() == "type::thing('user', 'alice')"
 
   def test_record_ref_helper_int_id(self) -> None:
     """Test record_ref() helper with integer ID."""
     ref = record_ref('post', 42)
     assert isinstance(ref, RecordRef)
-    assert ref.to_surql() == "type::record('post', 42)"
+    assert ref.to_surql() == "type::thing('post', 42)"
 
 
 class TestRecordRefInQueries:
@@ -294,21 +294,21 @@ class TestRecordRefInQueries:
     ref = record_ref('user', 'alice')
     query = Query().insert('post', {'title': 'Hello', 'author': ref})
     sql = query.to_surql()
-    assert "author: type::record('user', 'alice')" in sql
+    assert "author: type::thing('user', 'alice')" in sql
 
   def test_record_ref_in_update(self) -> None:
     """Test RecordRef used as a value in UPDATE query."""
     ref = record_ref('category', 'tech')
     query = Query().update('post:123', {'category': ref})
     sql = query.to_surql()
-    assert "category = type::record('category', 'tech')" in sql
+    assert "category = type::thing('category', 'tech')" in sql
 
   def test_record_ref_in_upsert(self) -> None:
     """Test RecordRef used as a value in UPSERT query."""
     ref = record_ref('org', 'acme')
     query = Query().upsert('member:alice', {'org': ref})
     sql = query.to_surql()
-    assert "org: type::record('org', 'acme')" in sql
+    assert "org: type::thing('org', 'acme')" in sql
 
 
 # =============================================================================
@@ -437,7 +437,7 @@ class TestSurrealFnAndRecordRefMixed:
       },
     )
     sql = query.to_surql()
-    assert "author: type::record('user', 'alice')" in sql
+    assert "author: type::thing('user', 'alice')" in sql
     assert 'created_at: time::now()' in sql
     assert "title: 'Hello'" in sql
 
@@ -673,10 +673,10 @@ class TestIntegrationAggregationQueries:
 
 
 class TestIntegrationRecordRefQueries:
-  """Integration tests verifying type::record() in full queries."""
+  """Integration tests verifying type::thing() in full queries."""
 
   def test_create_with_record_ref(self) -> None:
-    """Test CREATE query with type::record() reference."""
+    """Test CREATE query with type::thing() reference."""
     ref = record_ref('user', 'alice')
     query = Query().insert(
       'comment',
@@ -689,17 +689,17 @@ class TestIntegrationRecordRefQueries:
     expected_parts = [
       'CREATE comment CONTENT',
       "text: 'Great post!'",
-      "author: type::record('user', 'alice')",
+      "author: type::thing('user', 'alice')",
     ]
     for part in expected_parts:
       assert part in sql
 
   def test_update_with_record_ref(self) -> None:
-    """Test UPDATE query with type::record() reference."""
+    """Test UPDATE query with type::thing() reference."""
     ref = record_ref('department', 'engineering')
     query = Query().update('employee:123', {'dept': ref})
     sql = query.to_surql()
-    assert "dept = type::record('department', 'engineering')" in sql
+    assert "dept = type::thing('department', 'engineering')" in sql
 
 
 class TestIntegrationSurrealFnQueries:

--- a/tests/test_migration_history.py
+++ b/tests/test_migration_history.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from surql.connection.client import QueryError
+from surql.connection.client import DatabaseClient, QueryError
+from surql.connection.config import ConnectionConfig
 from surql.migration.history import (
   MIGRATION_TABLE_NAME,
   MigrationHistoryError,
@@ -162,7 +163,10 @@ class TestRecordMigration:
     # Last execute call is the CREATE ... SET with <datetime> cast.
     assert mock_db_client.execute.call_count >= 1
     statement, params = mock_db_client.execute.call_args[0]
-    assert 'CREATE type::record($table, $id)' in statement
+    # NOTE: must be `type::thing(table, id)`, not `type::record(table, id)`.
+    # In SurrealDB v3 the two-arg form of `type::record(value, type)` is a
+    # type coercion ("cast value into record<type>"), not a constructor.
+    assert 'CREATE type::thing($table, $id)' in statement
     assert '<datetime> $applied_at' in statement
     assert params['table'] == MIGRATION_TABLE_NAME
     assert params['version'] == '20240101_000000'
@@ -212,7 +216,7 @@ class TestRecordMigration:
     )
 
     _, params = mock_db_client.execute.call_args[0]
-    # Dashes, colons must become underscores so `type::record($table, $id)`
+    # Dashes, colons must become underscores so `type::thing($table, $id)`
     # accepts the value without bracket quoting.
     assert params['id'] == '2026_01_02T12_00_00'
 
@@ -769,3 +773,91 @@ class TestMigrationHistoryError:
     except MigrationHistoryError as error:
       assert str(error) == 'Wrapped error'
       assert error.__cause__ == cause
+
+
+class TestRecordMigrationAgainstEmbeddedDb:
+  """Regression: ``record_migration`` must succeed against a real SurrealDB.
+
+  Pre-1.5.6 the function emitted ``CREATE type::record($table, $id) ...``
+  which crashes on SurrealDB v3 with::
+
+    Expected a record<{id}> but cannot convert '{table}' into a record<{id}>
+
+  because the two-arg form of ``type::record(value, type)`` is a *type
+  coercion* (cast ``value`` into ``record<type>``), not a table+id
+  constructor. The fix replaces it with ``type::thing($table, $id)``,
+  which is the actual constructor.
+
+  The mock-based tests above check that ``record_migration`` *emits*
+  ``type::thing(...)`` -- this test additionally runs the SurrealQL
+  through the embedded ``mem://`` engine to guard against future
+  regressions where someone "fixes" the SurrealQL string but breaks the
+  semantics again. The embedded engine has the same query parser as the
+  remote server, so this catches the bug locally without a Docker
+  container.
+  """
+
+  @pytest.fixture
+  def anyio_backend(self) -> str:
+    """Embedded SurrealDB engine requires asyncio (uses
+    ``asyncio.get_running_loop()`` in its constructor)."""
+    return 'asyncio'
+
+  @pytest.mark.anyio
+  async def test_record_migration_writes_to_embedded_mem_db(self):
+    """Round-trip: insert, then read back via SELECT."""
+    config = ConnectionConfig(
+      _env_file=None,
+      url='mem://',
+      namespace='test',
+      database='test',
+      enable_live_queries=False,
+    )
+    client = DatabaseClient(config)
+    await client.connect()
+    try:
+      await record_migration(
+        client,
+        version='0001_init',
+        description='create users table',
+        checksum='abc123',
+        execution_time_ms=42,
+      )
+      # If we reach here, the CREATE succeeded -- this is the regression
+      # check. Now confirm the row is readable.
+      raw = await client.execute(f'SELECT * FROM {MIGRATION_TABLE_NAME}')
+      records = _extract_records(raw)
+      assert len(records) == 1
+      assert records[0]['version'] == '0001_init'
+      assert records[0]['description'] == 'create users table'
+      assert records[0]['checksum'] == 'abc123'
+      assert records[0]['execution_time_ms'] == 42
+    finally:
+      await client.disconnect()
+
+  @pytest.mark.anyio
+  async def test_record_migration_sanitized_id_round_trips(self):
+    """Versions with dashes/colons must sanitise to a valid record id and
+    still round-trip through ``type::thing``."""
+    config = ConnectionConfig(
+      _env_file=None,
+      url='mem://',
+      namespace='test',
+      database='test',
+      enable_live_queries=False,
+    )
+    client = DatabaseClient(config)
+    await client.connect()
+    try:
+      await record_migration(
+        client,
+        version='2026-05-02T12:00:00',
+        description='dashed and colon version',
+        checksum='c2',
+      )
+      raw = await client.execute(f'SELECT * FROM {MIGRATION_TABLE_NAME}')
+      records = _extract_records(raw)
+      assert len(records) == 1
+      assert records[0]['version'] == '2026-05-02T12:00:00'
+    finally:
+      await client.disconnect()

--- a/tests/test_query_ux_functions.py
+++ b/tests/test_query_ux_functions.py
@@ -119,7 +119,7 @@ class TestFunctionFactoryComposition:
     now = time_now_fn()
     query = Query().update('post:1', {'author': ref, 'updated_at': now})
     sql = query.to_surql()
-    assert "author = type::record('user', 'alice')" in sql
+    assert "author = type::thing('user', 'alice')" in sql
     assert 'updated_at = time::now()' in sql
 
 

--- a/tests/test_query_ux_type_record.py
+++ b/tests/test_query_ux_type_record.py
@@ -15,30 +15,30 @@ class TestTypeRecord:
   def test_type_record_with_string_id(self) -> None:
     fn = type_record('task', 'abc')
     assert isinstance(fn, SurrealFn)
-    assert fn.to_surql() == "type::record('task', 'abc')"
+    assert fn.to_surql() == "type::thing('task', 'abc')"
 
   def test_type_record_with_int_id(self) -> None:
     fn = type_record('post', 42)
-    assert fn.to_surql() == "type::record('post', 42)"
+    assert fn.to_surql() == "type::thing('post', 42)"
 
   def test_type_record_with_float_id(self) -> None:
     fn = type_record('metric', 3.14)
-    assert fn.to_surql() == "type::record('metric', 3.14)"
+    assert fn.to_surql() == "type::thing('metric', 3.14)"
 
   def test_type_record_with_bool_id(self) -> None:
     # Unusual but should not explode.
     fn = type_record('flag', True)
-    assert fn.to_surql() == "type::record('flag', true)"
+    assert fn.to_surql() == "type::thing('flag', true)"
 
   def test_type_record_with_record_id(self) -> None:
     rid: RecordID[Any] = RecordID(table='user', id='alice')
     fn = type_record('target', rid)
-    assert fn.to_surql() == "type::record('target', user:alice)"
+    assert fn.to_surql() == "type::thing('target', user:alice)"
 
   def test_type_record_with_nested_surreal_fn(self) -> None:
     inner = surql_fn('rand::uuid')
     fn = type_record('session', inner)
-    assert fn.to_surql() == "type::record('session', rand::uuid())"
+    assert fn.to_surql() == "type::thing('session', rand::uuid())"
 
   def test_type_record_escapes_single_quotes(self) -> None:
     fn = type_record('user', "o'brien")
@@ -52,20 +52,20 @@ class TestTypeRecord:
     fn = type_record('user', 'alice')
     query = Query().insert('post', {'title': 'Hello', 'author': fn})
     sql = query.to_surql()
-    assert "author: type::record('user', 'alice')" in sql
+    assert "author: type::thing('user', 'alice')" in sql
 
   def test_type_record_renders_raw_in_update(self) -> None:
     fn = type_record('user', 'alice')
     query = Query().update('post:123', {'author': fn})
     sql = query.to_surql()
-    assert "author = type::record('user', 'alice')" in sql
+    assert "author = type::thing('user', 'alice')" in sql
 
   def test_type_record_top_level_export(self) -> None:
     # Replicates the regression call from the issue description.
     from surql import type_record as top_level_type_record
 
     rendered = top_level_type_record('user', 'alice').to_surql()
-    assert rendered == "type::record('user', 'alice')"
+    assert rendered == "type::thing('user', 'alice')"
 
 
 class TestTypeThing:

--- a/tests/test_sdk_normalization.py
+++ b/tests/test_sdk_normalization.py
@@ -198,7 +198,7 @@ class TestSelectSingleRecordUnwrap:
     """Selecting a record ID unwraps the single-element list to a dict.
 
     Bug #15: record-id targets now route through raw
-    ``SELECT * FROM type::record($table, $id)`` rather than the SDK's
+    ``SELECT * FROM type::thing($table, $id)`` rather than the SDK's
     bare-string ``select``, so the mock is placed on ``query``.
     """
     mock_db_client._client.query = AsyncMock(return_value=[{'id': 'user:alice', 'name': 'Alice'}])

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Migration runner blocked on SurrealDB v3: `record_migration` emitted `CREATE type::record($table, $id) ...`, but in v3 `type::record(value, type)` (2-arg) is a *type coercion*, not a constructor. Calling `type::record('_migration_history', '0001_init')` raises `Expected a record<0001_init> but cannot convert '_migration_history' into a record<0001_init>`.
- The actual constructor is `type::thing(table, id)`. This PR switches `record_migration`, `DatabaseClient.select('table:id')`, and the `RecordRef` / `record_ref()` / `type_record()` / `type_thing()` helpers to emit `type::thing(...)`. Python helper names are preserved for source compatibility.
- Earlier docs claimed v3 renamed `type::thing` to `type::record` -- that was wrong. Corrected `v3-patterns.md`, `migration.md`, `query-ux.md`, `api/index.md`, `README.md`.
- Added `TestRecordMigrationAgainstEmbeddedDb` which round-trips `record_migration` through the embedded `mem://` engine so future regressions of this kind are caught locally without Docker.
- Bumps to `1.5.6` (1.5.5 was just released with the polling-LIVE fallback feature; this is a separate bug fix).

## Test plan

- [x] `uv run ruff check src tests` passes
- [x] `uv run ruff format --check src tests` passes
- [x] `uv run mypy src` passes
- [x] `uv run pytest --ignore=tests/integration` passes (2525 passed, 9 skipped)
- [x] New regression test `TestRecordMigrationAgainstEmbeddedDb` passes against `mem://`
- [ ] After merge: tag + GH release `v1.5.6`, confirm trusted-publishing workflow lands `oneiriq-surql==1.5.6` on PyPI