### PR TITLE
fix: 1.5.10 — don't auto-coerce composite string IDs (#85)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.10] - 2026-05-17
+
+### Fixed
+
+- **`_denormalize_params` over-coerced composite string IDs into RecordIDs (#85).**
+  The record-id detection regex accepted any `<word>:<rest>` shape, which
+  meant Cosmos-style composite identifiers (`BFS:community:1`,
+  `tenant:env:version`, `{org}:{repo}:{branch}`) were being silently
+  rewritten as `RecordID('BFS', 'community:1')` and rejected by SurrealDB
+  at the schema layer with `Couldn't coerce value for field `x`: Expected
+  `string` but found `BFS:community:1``. The id portion is now restricted
+  to `[^:\s/]+` (no extra colons, whitespace, or slashes), and the
+  angle-bracketed form `table:<id>` is matched by a parallel pattern that
+  treats anything inside the brackets as the id — including colons —
+  preserving SurrealDB v3's `community:<a:b:c>` escape hatch. Pattern
+  detection is still best-effort; callers wanting an unambiguous record
+  reference should pass `RecordID(table, id)` or `RecordRef(table, id)`
+  directly.
+
+  Regression coverage: `test_composite_string_id_not_record_id`,
+  `test_angle_bracketed_id_with_colons_still_record_id`.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2537 passed, 9 skipped, 2 xfailed**.
+
 ## [1.5.9] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.9"
+version = "1.5.10"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.9'
+__version__ = '1.5.10'
 
 __all__ = [
   # Configuration

--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -30,33 +30,43 @@ logger = structlog.get_logger(__name__)
 
 # Pattern matching SurrealDB record ID targets: "table:id" or "table:<complex_id>"
 #
-# Two guards keep this from over-matching:
+# Three guards keep this from over-matching:
 #
-# 1. Negative lookahead ``(?!//)`` after the colon excludes URL schemes
-#    (``http://``, ``https://``, ``ws://``, ``wss://``, ``file://``, ...) which
-#    share the ``<word>:<rest>`` shape with record-id literals. Without this
-#    guard, ``base_url='http://10.0.0.51:11434'`` was silently rewritten to
-#    ``RecordID('http', '//10.0.0.51:11434')`` and SurrealDB returned a coerce
-#    error in the result text of an otherwise OK-status query response.
+# 1. The id portion ``[^:\s/]+`` excludes additional colons, whitespace, and
+#    slashes. Without the "no extra colons" guard, composite string IDs that
+#    happen to contain colons -- e.g. ``BFS:community:1`` (Cosmos-style
+#    ``{tenant}:{type}:{version}``), ``tenant:env:version`` -- were being
+#    misread as ``RecordID('BFS', 'community:1')`` and rejected at the schema
+#    layer with "Couldn't coerce value for field `x`: Expected `string` but
+#    found `BFS:community:1`" (#85). The slash exclusion subsumes the prior
+#    ``(?!//)`` negative lookahead for URL schemes.
 #
-# 2. ``\S+$`` (non-whitespace, end-anchored) rejects prose. Real record IDs
-#    never contain whitespace; English content fields starting with a word
-#    plus colon (``Pattern: when ...``, ``TODO: implement``, ``Note: see``)
-#    were being coerced to ``RecordID('Pattern', ' when ...')`` and rejected
-#    at the schema layer with "Couldn't coerce value for field `content`...
-#    Expected `string` but found `Pattern:`...". Pattern-matching string
-#    values to detect record IDs is best-effort -- callers can always pass
-#    ``RecordID(table, id)`` explicitly when the target really is a record
-#    that happens to contain unusual characters.
+# 2. The angle-bracket form (``table:<id>``) is matched by the parallel
+#    ``_RECORD_ID_BRACKETED_PATTERN`` below, which permits anything inside
+#    the brackets including colons -- v3 supports ``community:<a:b:c>`` as a
+#    legitimate record ID, and the brackets are an explicit "treat as record"
+#    signal from the caller.
+#
+# 3. ``[^...\s]`` keeps the whitespace exclusion that rejects prose strings
+#    (``"TODO: implement"``, ``"Note: see ..."``) from being coerced.
+#
 # ``\Z`` (absolute end-of-string) is used instead of ``$`` so a trailing
-# newline doesn't slip past the anchor -- ``$`` matches at end-of-string OR
-# just before a final ``\n`` by default, which would let ``"user:alice\n"``
-# coerce.
-_RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:(?!//)\S+\Z')
+# newline doesn't slip past the anchor.
+#
+# Pattern-matching string values to detect record IDs is still best-effort --
+# callers who want an unambiguous record reference should pass
+# ``RecordID(table, id)`` or ``RecordRef(table, id)`` directly.
+_RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:[^:\s/]+\Z')
+_RECORD_ID_BRACKETED_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:<[^>]+>\Z')
 
 
 def _is_record_id_target(target: str) -> bool:
   """Check whether a target string looks like a single record ID (table:id).
+
+  Accepts both the bare ``table:id`` form (no extra colons in the id) and the
+  angle-bracketed ``table:<id>`` form (anything inside the brackets, including
+  colons, dots, hyphens). Composite string IDs like ``BFS:community:1`` are
+  intentionally NOT matched -- see the pattern comment above for #85 context.
 
   Args:
     target: The select target string
@@ -64,7 +74,7 @@ def _is_record_id_target(target: str) -> bool:
   Returns:
     True if target matches record ID format, False for table-only targets
   """
-  return bool(_RECORD_ID_PATTERN.match(target))
+  return bool(_RECORD_ID_PATTERN.match(target) or _RECORD_ID_BRACKETED_PATTERN.match(target))
 
 
 def _denormalize_params(value: Any) -> Any:
@@ -84,6 +94,10 @@ def _denormalize_params(value: Any) -> Any:
   """
   if isinstance(value, str) and _is_record_id_target(value):
     table, id_part = value.split(':', 1)
+    # Strip the angle-bracket wrappers from `table:<id>` form so the SDK gets
+    # the bare id (the brackets are SurrealQL syntax, not part of the id).
+    if id_part.startswith('<') and id_part.endswith('>'):
+      id_part = id_part[1:-1]
     return SdkRecordID(table, id_part)
   if isinstance(value, dict):
     return {k: _denormalize_params(v) for k, v in value.items()}

--- a/tests/test_sdk_normalization.py
+++ b/tests/test_sdk_normalization.py
@@ -100,6 +100,31 @@ class TestIsRecordIdTarget:
     assert _is_record_id_target('Reason: cache miss on the warm path') is False
     assert _is_record_id_target('Why: the schema requires it') is False
 
+  def test_composite_string_id_not_record_id(self) -> None:
+    """Composite IDs with multiple colons must not be detected as record IDs (#85).
+
+    Cosmos-style ``{tenant}:{entityType}:{version}`` identifiers (e.g.
+    ``BFS:community:1``) were being misread as ``RecordID('BFS', 'community:1')``
+    and rejected by SurrealDB at the schema layer with
+    ``Couldn't coerce value for field `x`: Expected `string` but found `BFS:community:1```.
+    The tightened pattern excludes any id portion containing additional colons.
+    Callers who really want a record reference with colons in the id should
+    use the angle-bracketed form ``community:<a:b:c>`` (matched separately).
+    """
+    assert _is_record_id_target('BFS:community:1') is False
+    assert _is_record_id_target('tenant:env:version') is False
+    assert _is_record_id_target('a:b:c:d') is False
+
+  def test_angle_bracketed_id_with_colons_still_record_id(self) -> None:
+    """The angle-bracketed form is an explicit "treat as record" signal.
+
+    Anything inside the brackets is the id portion, colons included. This
+    matches SurrealDB v3's bracketed-id syntax for unusual characters.
+    """
+    assert _is_record_id_target('community:<community-lakewood>') is True
+    assert _is_record_id_target('outlet:<alaskabeacon.com>') is True
+    assert _is_record_id_target('weird:<a:b:c>') is True
+
   def test_record_id_with_trailing_whitespace_not_record_id(self) -> None:
     """Record-ID-shaped strings with trailing whitespace are rejected.
 

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.8"
+version = "1.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes #85. The record-id detection regex was too permissive — any `<word>:<rest>` string got rewritten into a `RecordID` by `_denormalize_params`. Cosmos-style composite IDs like `BFS:community:1` were being mangled into `RecordID('BFS', 'community:1')` and rejected by SurrealDB with `Couldn't coerce value for field 'x': Expected 'string' but found 'BFS:community:1'`.

## Fix

- `_RECORD_ID_PATTERN` tightened: id portion is now `[^:\s/]+` (no extra colons, whitespace, or slashes).
- New parallel `_RECORD_ID_BRACKETED_PATTERN` matches `table:<id>` form — the bracketed form is an explicit "treat as record" signal, can contain colons (SurrealDB v3 supports `community:<a:b:c>`).
- `_denormalize_params` strips the angle-bracket wrappers before passing to `surrealdb.RecordID(table, id)` — the brackets are SurrealQL syntax, not part of the id.

## Tests

- 2 new regression tests: `test_composite_string_id_not_record_id`, `test_angle_bracketed_id_with_colons_still_record_id`.
- All existing tests still pass.
- 2537 passed, 9 skipped, 2 xfailed. lint+format+mypy clean.

## Test plan

- [x] Unit tests pass
- [x] Quality gate clean
- [ ] CI green
- [ ] Merged → tagged v1.5.10 → release created → publish.yml fires