### PR TITLE
fix: 1.5.11 — RecordID unicode brackets + _quote_value handles lists/dicts (#87)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.11] - 2026-05-17
+
+### Fixed
+
+- **`RecordID.__str__` emitted ASCII `<>` brackets that SurrealDB v3 rejects (#87).**
+  Every record id with special characters (hyphens, dots, colons) was being
+  formatted as `f'{table}:<{id}>'`, and SurrealDB's v3 parser fails on the
+  ASCII `<` with `Unexpected token \`<\`, expected a record-id key`. So
+  every `upsert_record`, `Query().upsert(...)`, `merge_record`, etc. call
+  that built its target via `str(RecordID(...))` for a composite id was
+  silently producing invalid SQL. The fix emits unicode brackets U+27E8 /
+  U+27E9 (`⟨⟩`) which v3's parser accepts. `RecordID.parse` now accepts
+  BOTH ASCII and unicode forms for backward-compat reads.
+
+- **`_quote_value` serialized lists and dicts as quoted strings (#87).**
+  Falling through to `f"'{str(value)}'"` meant `[1, 2, 3]` became the
+  literal SurrealQL string `'[1, 2, 3]'` and `{'k': 'v'}` became
+  `"{'k': 'v'}"`. SurrealDB then rejected these against `TYPE array` /
+  `TYPE object` columns. The fix emits proper SurrealQL array literals
+  (`[1, 2, 3]`) and object literals (`{k: 'v'}`), recursing through
+  `_quote_value` for nested values. Also added an explicit `RecordID`
+  branch that emits the record-id literal directly (e.g. `user:alice`,
+  `spec:⟨BFS:community:1⟩`) instead of quoting it as a string.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2539 passed, 9 skipped, 2 xfailed**.
+
 ## [1.5.10] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.10"
+version = "1.5.11"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.10'
+__version__ = '1.5.11'
 
 __all__ = [
   # Configuration

--- a/src/surql/types/operators.py
+++ b/src/surql/types/operators.py
@@ -579,16 +579,20 @@ def _validate_identifier(name: str, context: str = 'identifier') -> str:
 def _quote_value(value: Any) -> str:
   """Quote value for SurrealQL.
 
-  Handles SurrealFn, RecordRef, and query ``FunctionExpression`` instances
-  by rendering them as raw SurrealQL expressions instead of quoted strings.
+  Handles SurrealFn, RecordRef, RecordID, and query ``Expression`` instances
+  by rendering them as raw SurrealQL expressions. Lists and dicts emit native
+  SurrealQL array / object literals (recursing through `_quote_value`) — fixes
+  issue #87 where arrays were being serialized as quoted strings (`'[1, 2, 3]'`)
+  and rejected by SurrealDB as type mismatches against `TYPE array` columns.
 
   Args:
     value: Value to quote
 
   Returns:
-    Quoted string representation
+    SurrealQL expression suitable for embedding in a query
   """
   from surql.query.expressions import Expression
+  from surql.types.record_id import RecordID
   from surql.types.record_ref import RecordRef
   from surql.types.surreal_fn import SurrealFn
 
@@ -596,6 +600,11 @@ def _quote_value(value: Any) -> str:
     return 'NULL'
   elif isinstance(value, (SurrealFn, RecordRef, Expression)):
     return value.to_surql()
+  elif isinstance(value, RecordID):
+    # RecordID's `__str__` already produces the correct SurrealQL record-id
+    # literal (e.g. `community:⟨community-lakewood⟩`) — emit verbatim, NOT
+    # quoted as a string.
+    return str(value)
   elif isinstance(value, bool):
     return 'true' if value else 'false'
   elif isinstance(value, (int, float)):
@@ -605,6 +614,23 @@ def _quote_value(value: Any) -> str:
     # The order matters: \ must be escaped before ' to prevent \' escaping out
     escaped = value.replace('\\', '\\\\').replace("'", "\\'")
     return f"'{escaped}'"
+  elif isinstance(value, list):
+    return '[' + ', '.join(_quote_value(item) for item in value) + ']'
+  elif isinstance(value, dict):
+    parts = [f'{_quote_object_key(k)}: {_quote_value(v)}' for k, v in value.items()]
+    return '{' + ', '.join(parts) + '}'
   else:
     # For other types, convert to string and quote
     return f"'{str(value)}'"
+
+
+_BARE_KEY_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+
+def _quote_object_key(key: Any) -> str:
+  """Object keys: bare identifier if it qualifies, otherwise a quoted string."""
+  s = str(key)
+  if _BARE_KEY_RE.match(s):
+    return s
+  escaped = s.replace('\\', '\\\\').replace("'", "\\'")
+  return f"'{escaped}'"

--- a/src/surql/types/record_id.py
+++ b/src/surql/types/record_id.py
@@ -25,10 +25,10 @@ class RecordID[T](BaseModel):
     >>> str(record_id)
     'user:alice'
 
-    Complex IDs with angle brackets:
+    Complex IDs with unicode angle brackets (SurrealDB v3 syntax):
     >>> record_id = RecordID(table='outlet', id='alaskabeacon.com')
     >>> str(record_id)
-    'outlet:<alaskabeacon.com>'
+    'outlet:⟨alaskabeacon.com⟩'
 
     Parse from string:
     >>> record_id = RecordID.parse('user:123')
@@ -95,16 +95,19 @@ class RecordID[T](BaseModel):
     return not re.match(r'^[a-zA-Z0-9_]+$', id_value)
 
   def __str__(self) -> str:
-    """Return string representation in table:id format.
+    r"""Return string representation in table:id format.
 
-    Automatically adds angle brackets for complex IDs.
+    Automatically wraps complex IDs in **unicode** angle brackets (U+27E8 /
+    U+27E9) which are the SurrealDB v3 record-id escape syntax. ASCII `<` /
+    `>` are rejected by the v3 parser with `Unexpected token \`<\`, expected
+    a record-id key` (issue #87).
 
     Returns:
-      String in format 'table:id' or 'table:<id>'
+      String in format `'table:id'` or `'table:⟨id⟩'`.
     """
     id_str = str(self.id)
     if self._needs_angle_brackets(self.id):
-      return f'{self.table}:<{id_str}>'
+      return f'{self.table}:⟨{id_str}⟩'
     return f'{self.table}:{id_str}'
 
   def __repr__(self) -> str:
@@ -139,6 +142,9 @@ class RecordID[T](BaseModel):
 
       >>> RecordID.parse('outlet:<alaskabeacon.com>')
       RecordID(table='outlet', id='alaskabeacon.com')
+
+      >>> RecordID.parse('outlet:⟨alaskabeacon.com⟩')
+      RecordID(table='outlet', id='alaskabeacon.com')
     """
     if ':' not in record_id:
       raise ValueError(f'Invalid record ID format: {record_id}. Expected format: table:id')
@@ -154,8 +160,14 @@ class RecordID[T](BaseModel):
     if not id_str or not id_str.strip():
       raise ValueError(f'Invalid record ID: id cannot be empty in {record_id!r}')
 
-    # Strip angle brackets if present
-    if id_str.startswith('<') and id_str.endswith('>'):
+    # Strip angle brackets if present — accept BOTH ASCII `<>` (legacy / older
+    # serialization) and unicode `⟨⟩` (current SurrealDB v3 syntax).
+    if (
+      id_str.startswith('<')
+      and id_str.endswith('>')
+      or id_str.startswith('⟨')
+      and id_str.endswith('⟩')
+    ):
       id_str = id_str[1:-1]
 
     # Try to parse as int, otherwise keep as string

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -141,7 +141,7 @@ class TestRecordID:
 
     assert record_id.table == 'outlet'
     assert record_id.id == 'alaskabeacon.com'
-    assert str(record_id) == 'outlet:<alaskabeacon.com>'
+    assert str(record_id) == 'outlet:⟨alaskabeacon.com⟩'
 
   def test_record_id_with_composite_id(self) -> None:
     """Test RecordID with composite ID containing colon."""
@@ -149,13 +149,13 @@ class TestRecordID:
 
     assert record_id.table == 'document'
     assert record_id.id == 'alaskabeacon.com:01JEHE123'
-    assert str(record_id) == 'document:<alaskabeacon.com:01JEHE123>'
+    assert str(record_id) == 'document:⟨alaskabeacon.com:01JEHE123⟩'
 
   def test_record_id_with_hyphen_id(self) -> None:
     """Test RecordID with hyphen in ID (requires angle brackets)."""
     record_id = RecordID(table='user', id='john-doe')
 
-    assert str(record_id) == 'user:<john-doe>'
+    assert str(record_id) == 'user:⟨john-doe⟩'
 
   def test_record_id_simple_no_brackets(self) -> None:
     """Test that simple alphanumeric IDs don't get angle brackets."""
@@ -171,19 +171,19 @@ class TestRecordID:
 
   def test_record_id_parse_angle_bracket_domain(self) -> None:
     """Test parsing RecordID with angle bracket domain syntax."""
-    record_id = RecordID.parse('outlet:<alaskabeacon.com>')
+    record_id = RecordID.parse('outlet:⟨alaskabeacon.com⟩')
 
     assert record_id.table == 'outlet'
     assert record_id.id == 'alaskabeacon.com'
-    assert str(record_id) == 'outlet:<alaskabeacon.com>'
+    assert str(record_id) == 'outlet:⟨alaskabeacon.com⟩'
 
   def test_record_id_parse_angle_bracket_composite(self) -> None:
     """Test parsing RecordID with angle bracket composite ID."""
-    record_id = RecordID.parse('document:<domain.com:ulid123>')
+    record_id = RecordID.parse('document:⟨domain.com:ulid123⟩')
 
     assert record_id.table == 'document'
     assert record_id.id == 'domain.com:ulid123'
-    assert str(record_id) == 'document:<domain.com:ulid123>'
+    assert str(record_id) == 'document:⟨domain.com:ulid123⟩'
 
   def test_record_id_bidirectional_parsing_simple(self) -> None:
     """Test bidirectional parsing for simple IDs."""
@@ -223,13 +223,13 @@ class TestRecordID:
     assert record_id.table == 'outlet'
     assert record_id.id == 'alaskabeacon.com'
     # When converted to string, brackets are added automatically
-    assert str(record_id) == 'outlet:<alaskabeacon.com>'
+    assert str(record_id) == 'outlet:⟨alaskabeacon.com⟩'
 
   def test_record_id_to_surql_with_angle_brackets(self) -> None:
     """Test converting RecordID with angle brackets to SurrealQL format."""
     record_id = RecordID(table='outlet', id='alaskabeacon.com')
 
-    assert record_id.to_surql() == 'outlet:<alaskabeacon.com>'
+    assert record_id.to_surql() == 'outlet:⟨alaskabeacon.com⟩'
 
   def test_record_id_integer_no_brackets(self) -> None:
     """Test that integer IDs never get angle brackets."""
@@ -269,9 +269,31 @@ class TestQuoteValue:
     """Test quoting string with single quote (should escape)."""
     assert _quote_value("it's") == "'it\\'s'"
 
-  def test_quote_other_types(self) -> None:
-    """Test quoting other types (converts to string)."""
-    assert _quote_value([1, 2, 3]) == "'[1, 2, 3]'"
+  def test_quote_list_emits_array_literal(self) -> None:
+    """Lists serialize as native SurrealQL array literals (issue #87)."""
+    assert _quote_value([1, 2, 3]) == '[1, 2, 3]'
+    assert _quote_value(['a', 'b']) == "['a', 'b']"
+    assert _quote_value([]) == '[]'
+    # Nested
+    assert _quote_value([[1, 2], [3]]) == '[[1, 2], [3]]'
+
+  def test_quote_dict_emits_object_literal(self) -> None:
+    """Dicts serialize as native SurrealQL object literals (issue #87)."""
+    assert _quote_value({'name': 'Alice', 'age': 30}) == "{name: 'Alice', age: 30}"
+    assert _quote_value({}) == '{}'
+    # Nested dict
+    assert _quote_value({'meta': {'k': 'v'}}) == "{meta: {k: 'v'}}"
+    # Dict with list value
+    assert _quote_value({'tags': ['x', 'y']}) == "{tags: ['x', 'y']}"
+
+  def test_quote_record_id_emits_unbracketed_expression(self) -> None:
+    """RecordID values emit verbatim (not as quoted strings) so they reach SurrealDB as records."""
+    from surql.types.record_id import RecordID
+
+    rid = RecordID(table='user', id='alice')
+    assert _quote_value(rid) == 'user:alice'
+    composite = RecordID(table='spec', id='BFS:community:1')
+    assert _quote_value(composite) == 'spec:⟨BFS:community:1⟩'
 
 
 class TestComparisonOperators:

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.9"
+version = "1.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #87.

## Bugs

Two bugs in surql-py's higher-level helpers that silently produced invalid SurrealQL for any record with a composite id or array/object field values:

1. **`RecordID.__str__` used ASCII `<>` brackets.** Every `str(RecordID(table='x', id='a:b:c'))` emitted `'x:<a:b:c>'`. SurrealDB v3 rejects: `Parse error: Unexpected token \`<\`, expected a record-id key`. Fix: emit unicode `⟨⟩` (U+27E8 / U+27E9). `RecordID.parse` accepts both.
2. **`_quote_value` had no list/dict cases.** Fell through to `f"'{str(value)}'"` so `[1,2,3]` became the quoted string `'[1, 2, 3]'`. SurrealDB rejected against `TYPE array`. Fix: emit native array/object literals, recurse for nested values, plus explicit RecordID branch.

Together: unblocks every `upsert_record`/`Query().upsert()`/`merge_record` path with composite ids OR array/object field values.

## Tests

- 2539 passed, 9 skipped, 2 xfailed.
- Existing `test_types::TestRecordID` updated to assert unicode brackets.
- New: `test_quote_list_emits_array_literal`, `test_quote_dict_emits_object_literal`, `test_quote_record_id_emits_unbracketed_expression`.
- Lint + format + mypy clean.

## Test plan

- [x] Unit tests pass
- [x] Quality gate clean
- [ ] CI green
- [ ] Merged → v1.5.11 tag → release → PyPI