### PR TITLE
fix: 1.5.12 — _quote_value(None) emits SurrealQL NONE not NULL (#89)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.12] - 2026-05-17
+
+### Fixed
+
+- **`_quote_value(None)` emitted SurrealQL `NULL` but `TYPE option<X>` columns
+  require `NONE` (#89).** SurrealDB v3 strictly distinguishes NONE (absence of
+  value) from NULL (explicit null value); `option<X>` fields reject NULL with
+  `Expected 'none | X' but found 'NULL'`. Python `None` semantically maps to
+  "no value", so NONE is the correct serialization. Affects `_quote_value`,
+  `Eq('field', None)` (now renders `field = NONE`), and `value(None)`. Callers
+  who want a genuine NULL comparison should use the `IsNull` operator (already
+  exists and is unchanged). Surfaced immediately when downstream consumers
+  started using the helpers for nullable string/array fields.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2539 passed, 9 skipped, 2 xfailed**.
+
 ## [1.5.11] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.11"
+version = "1.5.12"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.11'
+__version__ = '1.5.12'
 
 __all__ = [
   # Configuration

--- a/src/surql/types/operators.py
+++ b/src/surql/types/operators.py
@@ -597,7 +597,11 @@ def _quote_value(value: Any) -> str:
   from surql.types.surreal_fn import SurrealFn
 
   if value is None:
-    return 'NULL'
+    # SurrealDB v3 distinguishes NONE (absence of value) from NULL (explicit
+    # null). For `TYPE option<X>` columns the server expects NONE and rejects
+    # NULL with `Couldn't coerce value: Expected `none | X` but found `NULL``.
+    # Python `None` maps to "no value", so NONE is correct.
+    return 'NONE'
   elif isinstance(value, (SurrealFn, RecordRef, Expression)):
     return value.to_surql()
   elif isinstance(value, RecordID):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -576,12 +576,12 @@ class TestBuildUpsertQuery:
     assert 'admin' in query
     assert '"role"' in query or "'role'" in query
 
-  def test_build_upsert_query_with_null_values(self) -> None:
-    """Test building upsert query with null values."""
+  def test_build_upsert_query_with_none_values(self) -> None:
+    """None values render as SurrealQL `NONE` (issue #89)."""
     items = [{'name': 'Alice', 'age': None}]
     query = build_upsert_query('users', items)
 
-    assert 'NULL' in query
+    assert 'NONE' in query
 
   def test_build_upsert_query_with_boolean_values(self) -> None:
     """Test building upsert query with boolean values."""

--- a/tests/test_query_expressions.py
+++ b/tests/test_query_expressions.py
@@ -152,9 +152,9 @@ class TestValueBuilder:
     assert expr.to_surql() == 'false'
 
   def test_value_none(self):
-    """Test None value."""
+    """Test None value — emits SurrealQL NONE (issue #89)."""
     expr = value(None)
-    assert expr.to_surql() == 'NULL'
+    assert expr.to_surql() == 'NONE'
 
 
 class TestFunctionBuilder:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -241,9 +241,15 @@ class TestRecordID:
 class TestQuoteValue:
   """Test suite for _quote_value helper function."""
 
-  def test_quote_none(self) -> None:
-    """Test quoting None value."""
-    assert _quote_value(None) == 'NULL'
+  def test_quote_none_emits_surreal_none(self) -> None:
+    """Python None serializes as SurrealQL `NONE`, not `NULL`.
+
+    SurrealDB v3 distinguishes the two (NONE = absence, NULL = explicit
+    null). `TYPE option<X>` columns reject NULL with `Expected 'none | X'
+    but found 'NULL'` — Python `None` semantically maps to "no value", so
+    NONE is the correct serialization. See issue #89.
+    """
+    assert _quote_value(None) == 'NONE'
 
   def test_quote_bool_true(self) -> None:
     """Test quoting boolean True."""
@@ -545,10 +551,15 @@ class TestOperatorBaseClass:
 class TestOperatorEdgeCases:
   """Test suite for operator edge cases."""
 
-  def test_eq_with_null_value(self) -> None:
-    """Test Eq operator with None value."""
+  def test_eq_with_none_value(self) -> None:
+    """`Eq('field', None)` renders `field = NONE` (issue #89).
+
+    SurrealDB v3 distinguishes NONE from NULL — for absence-of-value
+    comparisons against `option<X>` columns NONE is correct. If you genuinely
+    want to compare against an explicit NULL, use `IsNull` operator instead.
+    """
     op = Eq('deleted_at', None)
-    assert op.to_surql() == 'deleted_at = NULL'
+    assert op.to_surql() == 'deleted_at = NONE'
 
   def test_eq_with_bool_value(self) -> None:
     """Test Eq operator with boolean value."""

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.11"
+version = "1.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #89. Python None → SurrealQL NONE (was NULL). v3 `TYPE option<X>` columns reject NULL. 2539 tests pass.