### PR TITLE
fix: 1.5.13 — bracketed-target handling in db.select/merge/update/delete (#91)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.13] - 2026-05-17
+
+### Fixed
+
+- **`db.select` / `db.merge` / `db.update` / `db.delete` mishandled bracketed
+  record-id targets emitted by `str(RecordID(...))` (#91).** After 1.5.11
+  switched `RecordID.__str__` to unicode `⟨⟩` brackets for v3 compatibility,
+  callers like `get_record(table, RecordID(table, 'a-b'), Model)` produced a
+  target string `'table:⟨a-b⟩'`. `db.select` was passing the bracketed inner
+  `'⟨a-b⟩'` as the `$id` param to `type::record($table, $id)`, so SurrealDB
+  looked up `table:'⟨a-b⟩'` (a different, non-existent record) and returned
+  None. Same hazard existed for `db.merge/update/delete` paths where the SDK's
+  string parser doesn't understand the bracketed form. The fix:
+
+  - Extended `_RECORD_ID_BRACKETED_PATTERN` to match both ASCII `<>` and
+    unicode `⟨⟩` brackets.
+  - Added `_strip_record_id_brackets` (used by `_denormalize_params` and
+    `db.select`'s `type::record` dispatch) so the inner id is stripped of
+    brackets before lookup.
+  - Added `_normalize_target` (used by `db.merge/update/delete`) which
+    converts any record-id-shaped string target into an `SdkRecordID`
+    object so the SDK gets a type it understands instead of trying to
+    parse the bracketed string itself.
+
+  Surfaced immediately when downstream consumers started using `get_record`
+  + `merge_record` for entities with hyphenated record ids.
+
+- **`_denormalize_params` didn't recognize surql's own `RecordID` (#91).** When
+  callers built `merge_record(table, id, {'community': RecordID(...)})`, the
+  surql `RecordID` wrapper sailed straight through `_denormalize_params` and
+  hit the SDK's CBOR encoder, which raised
+  `('no encoder for type ', <class 'surql.types.record_id.RecordID'>)`.
+  Added a `SurqlRecordID -> SdkRecordID` conversion branch so callers can hand
+  the helpers either a string or a `RecordID` instance and have either work.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2539 passed**, 9 skipped, 2 xfailed.
+
 ## [1.5.12] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.12"
+version = "1.5.13"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.12'
+__version__ = '1.5.13'
 
 __all__ = [
   # Configuration

--- a/src/surql/connection/client.py
+++ b/src/surql/connection/client.py
@@ -57,7 +57,34 @@ logger = structlog.get_logger(__name__)
 # callers who want an unambiguous record reference should pass
 # ``RecordID(table, id)`` or ``RecordRef(table, id)`` directly.
 _RECORD_ID_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:[^:\s/]+\Z')
-_RECORD_ID_BRACKETED_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:<[^>]+>\Z')
+# Accept both ASCII (`<>`) and unicode (`⟨⟩`) bracket forms. RecordID.__str__
+# emits the unicode form for SurrealDB v3 compatibility (#87), but callers
+# may still pass ASCII-bracketed strings from older serializations.
+_RECORD_ID_BRACKETED_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*:(?:<[^>]+>|⟨[^⟩]+⟩)\Z')
+
+
+def _strip_record_id_brackets(id_part: str) -> str:
+  """Remove ASCII `<>` or unicode `⟨⟩` brackets around a record id."""
+  if id_part.startswith('<') and id_part.endswith('>'):
+    return id_part[1:-1]
+  if id_part.startswith('⟨') and id_part.endswith('⟩'):
+    return id_part[1:-1]
+  return id_part
+
+
+def _normalize_target(target: str) -> Any:
+  """Convert a record-id-shaped target to an SDK RecordID; pass tables through.
+
+  The SurrealDB Python SDK accepts either a plain table name (`'user'`) for
+  table-level ops or an `SdkRecordID` for record-level ops. Bracketed
+  record-id strings (`'user:⟨a-b⟩'`) confuse the SDK's string parser, so we
+  pre-convert to `SdkRecordID(table, bare_id)` for any bracketed/composite
+  shape. Tables (no colon) pass through unchanged.
+  """
+  if not _is_record_id_target(target):
+    return target
+  table, id_part = target.split(':', 1)
+  return SdkRecordID(table, _strip_record_id_brackets(id_part))
 
 
 def _is_record_id_target(target: str) -> bool:
@@ -78,7 +105,7 @@ def _is_record_id_target(target: str) -> bool:
 
 
 def _denormalize_params(value: Any) -> Any:
-  """Recursively convert record ID strings back to SDK RecordID objects.
+  """Recursively convert record ID strings and surql RecordIDs to SDK RecordIDs.
 
   When consumers receive normalized responses (RecordID -> string), they may
   pass those strings back as field values in subsequent create/update calls.
@@ -86,18 +113,25 @@ def _denormalize_params(value: Any) -> Any:
   function detects strings matching the ``table:id`` pattern and converts them
   back to ``surrealdb.RecordID`` objects before sending to the SDK.
 
+  surql's own ``RecordID`` pydantic wrapper is also converted to the SDK type
+  here — the SDK's CBOR encoder only knows about ``surrealdb.RecordID``.
+
   Args:
     value: Any value from user-provided data (dicts, lists, scalars)
 
   Returns:
     The value with record ID strings replaced by SDK RecordID objects
   """
+  # Local import to avoid a top-level cycle (types -> connection -> types).
+  from surql.types.record_id import RecordID as SurqlRecordID
+
+  if isinstance(value, SurqlRecordID):
+    return SdkRecordID(value.table, value.id)
   if isinstance(value, str) and _is_record_id_target(value):
     table, id_part = value.split(':', 1)
-    # Strip the angle-bracket wrappers from `table:<id>` form so the SDK gets
-    # the bare id (the brackets are SurrealQL syntax, not part of the id).
-    if id_part.startswith('<') and id_part.endswith('>'):
-      id_part = id_part[1:-1]
+    # Strip the angle-bracket wrappers (ASCII `<>` or unicode `⟨⟩`) so the SDK
+    # gets the bare id (the brackets are SurrealQL syntax, not part of the id).
+    id_part = _strip_record_id_brackets(id_part)
     return SdkRecordID(table, id_part)
   if isinstance(value, dict):
     return {k: _denormalize_params(v) for k, v in value.items()}
@@ -465,6 +499,10 @@ class DatabaseClient:
 
         if _is_record_id_target(target):
           table, id_part = target.split(':', 1)
+          # Strip angle-bracket wrappers (ASCII `<>` or unicode `⟨⟩`) so the
+          # value passed to type::record($table, $id) is the bare id, not the
+          # bracket-wrapped SurrealQL syntax form.
+          id_part = _strip_record_id_brackets(id_part)
           raw = await self._client.query(
             'SELECT * FROM type::record($table, $id)',
             {'table': table, 'id': id_part},
@@ -528,7 +566,7 @@ class DatabaseClient:
     async with self._semaphore:
       try:
         self._log.debug('executing_update', target=target, data=data)
-        result = await self._client.update(target, _denormalize_params(data))
+        result = await self._client.update(_normalize_target(target), _denormalize_params(data))
         return _normalize_sdk_value(result)
       except Exception as e:
         self._log.error('update_failed', error=str(e), target=target)
@@ -554,7 +592,7 @@ class DatabaseClient:
     async with self._semaphore:
       try:
         self._log.debug('executing_merge', target=target, data=data)
-        result = await self._client.merge(target, _denormalize_params(data))
+        result = await self._client.merge(_normalize_target(target), _denormalize_params(data))
         return _normalize_sdk_value(result)
       except Exception as e:
         self._log.error('merge_failed', error=str(e), target=target)
@@ -579,7 +617,7 @@ class DatabaseClient:
     async with self._semaphore:
       try:
         self._log.debug('executing_delete', target=target)
-        result = await self._client.delete(target)
+        result = await self._client.delete(_normalize_target(target))
         return _normalize_sdk_value(result)
       except Exception as e:
         self._log.error('delete_failed', error=str(e), target=target)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -446,26 +446,52 @@ class TestDatabaseClient:
 
   @pytest.mark.anyio
   async def test_update_success(self, mock_db_client: DatabaseClient) -> None:
-    """Test successful UPDATE operation."""
+    """Test successful UPDATE operation.
+
+    Targets shaped like record IDs (`'user:alice'`) are normalized to SDK
+    `RecordID(table, id)` objects before reaching the underlying client so the
+    SDK doesn't have to re-parse the string (and so bracketed unicode forms
+    like `'user:⟨a-b⟩'` work — #91).
+    """
+    from surrealdb import RecordID as SdkRecordID
+
     data = {'status': 'active'}
     await mock_db_client.update('user:alice', data)
 
-    mock_db_client._client.update.assert_called_once_with('user:alice', data)
+    mock_db_client._client.update.assert_called_once()
+    call_args = mock_db_client._client.update.call_args
+    assert isinstance(call_args[0][0], SdkRecordID)
+    assert call_args[0][0].table_name == 'user'
+    assert call_args[0][0].id == 'alice'
+    assert call_args[0][1] == data
 
   @pytest.mark.anyio
   async def test_merge_success(self, mock_db_client: DatabaseClient) -> None:
-    """Test successful MERGE operation."""
+    """Test successful MERGE operation. Target normalized to SDK RecordID — see #91."""
+    from surrealdb import RecordID as SdkRecordID
+
     data = {'status': 'active'}
     await mock_db_client.merge('user:alice', data)
 
-    mock_db_client._client.merge.assert_called_once_with('user:alice', data)
+    mock_db_client._client.merge.assert_called_once()
+    call_args = mock_db_client._client.merge.call_args
+    assert isinstance(call_args[0][0], SdkRecordID)
+    assert call_args[0][0].table_name == 'user'
+    assert call_args[0][0].id == 'alice'
+    assert call_args[0][1] == data
 
   @pytest.mark.anyio
   async def test_delete_success(self, mock_db_client: DatabaseClient) -> None:
-    """Test successful DELETE operation."""
+    """Test successful DELETE operation. Target normalized to SDK RecordID — see #91."""
+    from surrealdb import RecordID as SdkRecordID
+
     await mock_db_client.delete('user:alice')
 
-    mock_db_client._client.delete.assert_called_once_with('user:alice')
+    mock_db_client._client.delete.assert_called_once()
+    call_args = mock_db_client._client.delete.call_args
+    assert isinstance(call_args[0][0], SdkRecordID)
+    assert call_args[0][0].table_name == 'user'
+    assert call_args[0][0].id == 'alice'
 
   @pytest.mark.anyio
   async def test_insert_relation_success(self, mock_db_client: DatabaseClient) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.12"
+version = "1.5.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Two bugs surfaced when downstream consumers started using `get_record` + `merge_record` for entities with hyphenated record ids (e.g. `table:a-b`):

1. **Bracketed targets mishandled in `db.select` / `db.merge` / `db.update` / `db.delete`.** Since 1.5.11 switched `RecordID.__str__` to unicode `⟨⟩` brackets for v3 compatibility, callers like `get_record(table, RecordID(table, 'a-b'), Model)` produced a target string `'table:⟨a-b⟩'`. `db.select` was passing the bracketed inner `'⟨a-b⟩'` straight into `type::record($table, $id)`, so SurrealDB looked up `table:'⟨a-b⟩'` (a different, non-existent record) and returned `None`. The merge/update/delete paths hit the same hazard via the SDK's string parser.

2. **`_denormalize_params` didn't recognize surql's own `RecordID`.** When callers built `merge_record(table, id, {'community': RecordID(...)})`, the surql `RecordID` wrapper sailed straight through `_denormalize_params` and hit the SDK's CBOR encoder, which raised `('no encoder for type ', <class 'surql.types.record_id.RecordID'>)`.

## Fixes

- Extended `_RECORD_ID_BRACKETED_PATTERN` to match both ASCII `<>` and unicode `⟨⟩`.
- Added `_strip_record_id_brackets` (used by `_denormalize_params` and `db.select`'s `type::record` dispatch) so the inner id is stripped of brackets before lookup.
- Added `_normalize_target` (used by `db.merge/update/delete`) which converts any record-id-shaped string target into an `SdkRecordID` so the SDK gets a type it understands.
- Added a `SurqlRecordID -> SdkRecordID` conversion branch in `_denormalize_params` so callers can pass either a string or a `RecordID` instance and have either work.
- Updated `tests/test_connection.py` to assert the new SdkRecordID-shaped SDK calls.

## Test plan

- [x] `uv run pytest --no-cov --ignore=tests/integration -q` — **2539 passed**, 9 skipped, 2 xfailed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src --strict` — clean
- [ ] CI green on PR
- [ ] Publish workflow reaches prod-env gate; manual approval triggers PyPI upload