### PR TITLE
fix: 1.5.14 — typed record<target> field emission (#92)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.14] - 2026-05-17
+
+### Added
+
+- **Typed `record<target>` field emission for cross-table introspection (#92).**
+  Until now, `field('author', FieldType.RECORD, value='type::record("user", $value)')`
+  emitted `DEFINE FIELD author ... TYPE record VALUE type::record("user", $value)`
+  — bare `TYPE record` plus a VALUE coercion. SurrealDB stored the link correctly,
+  but the type system carried no signal of WHICH table the field links to, so
+  introspection-driven tools (Surrealist's Table Graph designer, ERD generators,
+  any code reading `INFO FOR TABLE`) couldn't render the cross-table arrow.
+
+  Two new behaviors:
+
+  - **Explicit:** `field(name, FieldType.RECORD, target_table='user')` emits
+    `DEFINE FIELD name ON TABLE ... TYPE record<user>;` (`option<record<user>>`
+    when `nullable=True`). No `VALUE` clause — the parameterized type enforces
+    the same constraint.
+  - **Auto-detection (backward-compat):** when `target_table` isn't passed but
+    `value=` matches the canonical `type::record("X", $value)` coercion pattern,
+    the emitter lifts X into `target_table=X` automatically and drops the
+    now-redundant VALUE clause. Existing schemas that used the `value=`
+    convention get the typed form on the next migration with zero code changes.
+
+  Non-canonical `value=` expressions (e.g. `value='string::lowercase($value.id)'`)
+  are left untouched — only the exact `type::record("X", $value)` shape triggers
+  the upgrade, so callers who deliberately wrote a custom coercion keep their
+  VALUE clause.
+
+  Applies to both `schema/sql.py::_generate_field_sql` (initial DEFINE FIELD)
+  and `migration/diff.py::_field_to_sql` (incremental ADD FIELD diffs). 7
+  regression tests in `tests/test_schema_sql.py::TestTypedRecordFields` and
+  `tests/test_migration_generator.py::TestAddFieldBackfillSQL`.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2546 passed, 9 skipped, 2 xfailed**.
+
 ## [1.5.13] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.13"
+version = "1.5.14"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.13'
+__version__ = '1.5.14'
 
 __all__ = [
   # Configuration

--- a/src/surql/migration/diff.py
+++ b/src/surql/migration/diff.py
@@ -10,7 +10,7 @@ import structlog
 
 from surql.migration.models import DiffOperation, SchemaDiff
 from surql.schema.edge import EdgeDefinition
-from surql.schema.fields import FieldDefinition
+from surql.schema.fields import FieldDefinition, FieldType, _detect_target_table_from_value
 from surql.schema.table import (
   EventDefinition,
   IndexDefinition,
@@ -634,7 +634,18 @@ def _field_to_sql(table_name: str, field: FieldDefinition) -> str:
   Returns:
     SQL statement string
   """
-  type_clause = f'option<{field.type.value}>' if field.nullable else field.type.value
+  # Mirror schema/sql.py: RECORD fields with target_table emit `record<X>`
+  # and drop the redundant `VALUE type::record("X", $value)` coercion.
+  if field.type == FieldType.RECORD and field.target_table:
+    base_type = f'record<{field.target_table}>'
+    drop_value = bool(
+      field.value and _detect_target_table_from_value(field.value) == field.target_table
+    )
+  else:
+    base_type = field.type.value
+    drop_value = False
+
+  type_clause = f'option<{base_type}>' if field.nullable else base_type
   sql = f'DEFINE FIELD {field.name} ON TABLE {table_name} TYPE {type_clause}'
 
   if field.assertion:
@@ -644,7 +655,7 @@ def _field_to_sql(table_name: str, field: FieldDefinition) -> str:
     _validate_default_value(field.default)
     sql += f' DEFAULT {field.default}'
 
-  if field.value:
+  if field.value and not drop_value:
     _validate_default_value(field.value)
     sql += f' VALUE {field.value}'
 

--- a/src/surql/schema/fields.py
+++ b/src/surql/schema/fields.py
@@ -14,6 +14,25 @@ from surql.types.reserved import check_reserved_word
 
 _FIELD_NAME_PART_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
 
+# Recognizes the `type::record("<table>", $value)` coercion pattern in a
+# `value=` arg so we can lift the target table into the field's TYPE clause
+# (`record<table>`). Matches both single and double quotes, optional whitespace.
+_TYPE_RECORD_COERCION_PATTERN = re.compile(
+  r'type::record\s*\(\s*["\']([a-zA-Z_][a-zA-Z0-9_]*)["\']\s*,\s*\$value\s*\)\s*\Z'
+)
+
+
+def _detect_target_table_from_value(value: str | None) -> str | None:
+  """If `value` is the canonical record-coercion expression, return the target table.
+
+  `type::record("plan", $value)` -> `"plan"`. Returns None for anything else,
+  including more complex VALUE expressions a caller deliberately wrote.
+  """
+  if not value:
+    return None
+  m = _TYPE_RECORD_COERCION_PATTERN.match(value.strip())
+  return m.group(1) if m else None
+
 
 class FieldType(Enum):
   """SurrealDB field types.
@@ -73,6 +92,14 @@ class FieldDefinition(BaseModel):
   # NONE in addition to values of the declared type. Required for SCHEMAFULL
   # tables whose source data may omit the field.
   nullable: bool = False
+  # For RECORD fields: the target table this field links to. When set, the
+  # emitter writes `TYPE record<{target_table}>` (parameterized) instead of
+  # bare `TYPE record`, which is what SurrealDB's introspection (and tools
+  # like Surrealist's graph designer) need to render cross-table relationships.
+  # If unset on a RECORD field but `value` matches the canonical
+  # `type::record("X", $value)` coercion pattern, the emitter auto-detects X
+  # from the value string and treats it as `target_table=X`.
+  target_table: str | None = None
 
   model_config = ConfigDict(frozen=True)
 
@@ -91,6 +118,7 @@ def field(
   readonly: bool = False,
   flexible: bool = False,
   nullable: bool = False,
+  target_table: str | None = None,
 ) -> FieldDefinition:
   """Create a field definition.
 
@@ -105,6 +133,14 @@ def field(
     permissions: Optional dict of permission rules (select, create, update, delete)
     readonly: If True, field value cannot be modified after creation
     flexible: If True, field allows flexible schema
+    nullable: If True, emits `TYPE option<X>` so the column accepts NONE.
+    target_table: For RECORD fields, the target table — emits
+      `TYPE record<{target_table}>` (parameterized) so SurrealDB introspection
+      and Surrealist's graph designer can render cross-table relationships.
+      If left unset on a RECORD field but `value` matches the canonical
+      `type::record("X", $value)` coercion pattern, the emitter auto-detects X
+      and treats it as `target_table=X` (so existing schemas get the upgrade
+      with no code changes — see #92).
 
   Returns:
     Immutable FieldDefinition instance
@@ -115,12 +151,21 @@ def field(
 
     >>> field('age', FieldType.INT, assertion='$value >= 0 AND $value <= 150')
     FieldDefinition(name='age', type=FieldType.INT, assertion='$value >= 0 AND $value <= 150', ...)
+
+    >>> field('author', FieldType.RECORD, target_table='user')  # explicit
+    >>> field('author', FieldType.RECORD, value='type::record("user", $value)')  # auto-detected
   """
   _validate_field_name(name)
 
   reserved_warning = check_reserved_word(name)
   if reserved_warning is not None:
     warnings.warn(reserved_warning, stacklevel=2)
+
+  # If the caller didn't pass target_table explicitly but supplied the canonical
+  # `type::record("X", $value)` coercion as `value=`, lift X into target_table
+  # so the emitter writes `record<X>` and (optionally) drops the redundant VALUE.
+  if field_type == FieldType.RECORD and target_table is None:
+    target_table = _detect_target_table_from_value(value)
 
   return FieldDefinition(
     name=name,
@@ -132,6 +177,7 @@ def field(
     readonly=readonly,
     flexible=flexible,
     nullable=nullable,
+    target_table=target_table,
   )
 
 

--- a/src/surql/schema/sql.py
+++ b/src/surql/schema/sql.py
@@ -7,7 +7,7 @@ directly from surql schema definitions without using the migration system.
 
 from surql.schema.access import AccessDefinition, AccessType
 from surql.schema.edge import EdgeDefinition, EdgeMode
-from surql.schema.fields import FieldDefinition
+from surql.schema.fields import FieldDefinition, FieldType, _detect_target_table_from_value
 from surql.schema.table import (
   EventDefinition,
   IndexDefinition,
@@ -64,7 +64,8 @@ def _generate_field_sql(
     SurrealQL DEFINE FIELD statement
   """
   ine = _ine_clause(if_not_exists)
-  type_clause = f'option<{field_def.type.value}>' if field_def.nullable else field_def.type.value
+  base_type, drop_value = _resolve_type_clause(field_def)
+  type_clause = f'option<{base_type}>' if field_def.nullable else base_type
   sql = f'DEFINE FIELD{ine} {field_def.name} ON TABLE {table_name} TYPE {type_clause}'
 
   if field_def.assertion:
@@ -73,7 +74,7 @@ def _generate_field_sql(
   if field_def.default:
     sql += f' DEFAULT {field_def.default}'
 
-  if field_def.value:
+  if field_def.value and not drop_value:
     sql += f' VALUE {field_def.value}'
 
   if field_def.readonly:
@@ -84,6 +85,23 @@ def _generate_field_sql(
 
   sql += ';'
   return sql
+
+
+def _resolve_type_clause(field_def: FieldDefinition) -> tuple[str, bool]:
+  """Return `(base_type_clause, drop_value)` honoring RECORD target_table.
+
+  For RECORD fields with a `target_table`, emit `record<target>` instead of
+  bare `record` so SurrealDB's introspection (and Surrealist's graph designer)
+  can render cross-table relationships. If the value arg was the canonical
+  `type::record("target", $value)` coercion, it's now redundant — the type
+  parameter enforces the same thing — so signal back to drop it.
+  """
+  if field_def.type == FieldType.RECORD and field_def.target_table:
+    drop_value = bool(
+      field_def.value and _detect_target_table_from_value(field_def.value) == field_def.target_table
+    )
+    return f'record<{field_def.target_table}>', drop_value
+  return field_def.type.value, False
 
 
 def _generate_index_sql(

--- a/tests/test_migration_generator.py
+++ b/tests/test_migration_generator.py
@@ -662,6 +662,33 @@ class TestAddFieldBackfillSQL:
 
     assert 'DEFINE FIELD middle_name ON TABLE user TYPE option<string>;' in diff.forward_sql
 
+  def test_record_with_target_table_emits_parameterized_type(self) -> None:
+    """RECORD field with `target_table` -> `record<X>` in diff SQL (matches schema/sql.py)."""
+    field = FieldDefinition(
+      name='author',
+      type=FieldType.RECORD,
+      target_table='user',
+    )
+
+    diff = _generate_add_field_diff('post', field)
+
+    assert 'DEFINE FIELD author ON TABLE post TYPE record<user>;' in diff.forward_sql
+
+  def test_record_with_target_table_drops_redundant_value_coercion(self) -> None:
+    """When `value` is the canonical `type::record("X", $value)`, drop it (#92)."""
+    field = FieldDefinition(
+      name='author',
+      type=FieldType.RECORD,
+      target_table='user',
+      value='type::record("user", $value)',
+      nullable=True,
+    )
+
+    diff = _generate_add_field_diff('post', field)
+
+    assert 'DEFINE FIELD author ON TABLE post TYPE option<record<user>>;' in diff.forward_sql
+    assert 'VALUE' not in diff.forward_sql
+
   def test_field_with_string_default_includes_backfill(self) -> None:
     """Test backfill SQL with string default value."""
     field = FieldDefinition(

--- a/tests/test_schema_sql.py
+++ b/tests/test_schema_sql.py
@@ -523,3 +523,93 @@ class TestIfNotExists:
     assert any(
       s == 'DEFINE INDEX IF NOT EXISTS title_idx ON TABLE post COLUMNS title;' for s in stmts
     )
+
+
+class TestTypedRecordFields:
+  """RECORD fields emit `record<target>` so SurrealDB introspection picks up the link (#92)."""
+
+  def test_record_with_explicit_target_table_emits_parameterized_type(self) -> None:
+    """`target_table='user'` -> `TYPE record<user>` instead of bare `TYPE record`."""
+    table = table_schema(
+      'post',
+      mode=TableMode.SCHEMAFULL,
+      fields=[field('author', FieldType.RECORD, target_table='user')],
+    )
+
+    stmts = generate_table_sql(table)
+
+    assert 'DEFINE FIELD author ON TABLE post TYPE record<user>;' in stmts
+
+  def test_record_with_target_table_and_nullable_wraps_in_option(self) -> None:
+    """`nullable=True` + typed RECORD -> `TYPE option<record<X>>`."""
+    table = table_schema(
+      'post',
+      mode=TableMode.SCHEMAFULL,
+      fields=[field('author', FieldType.RECORD, target_table='user', nullable=True)],
+    )
+
+    stmts = generate_table_sql(table)
+
+    assert 'DEFINE FIELD author ON TABLE post TYPE option<record<user>>;' in stmts
+
+  def test_record_with_value_coercion_auto_detects_target_table(self) -> None:
+    """`value='type::record("user", $value)'` is recognized and lifted into the TYPE.
+
+    Backward-compat path: existing schemas that used `value=` to encode the
+    target table now automatically get the typed form without code changes.
+    The redundant VALUE clause is dropped (the type parameter enforces it).
+    """
+    table = table_schema(
+      'post',
+      mode=TableMode.SCHEMAFULL,
+      fields=[
+        field('author', FieldType.RECORD, value='type::record("user", $value)', nullable=True),
+      ],
+    )
+
+    stmts = generate_table_sql(table)
+
+    assert 'DEFINE FIELD author ON TABLE post TYPE option<record<user>>;' in stmts
+    # No leftover VALUE clause — it was redundant.
+    assert not any('VALUE type::record' in s for s in stmts)
+
+  def test_record_with_custom_value_keeps_bare_record_and_value(self) -> None:
+    """A non-canonical `value=` expression is left alone — only the exact
+    `type::record("X", $value)` pattern triggers the upgrade.
+    """
+    table = table_schema(
+      'post',
+      mode=TableMode.SCHEMAFULL,
+      fields=[
+        field('author', FieldType.RECORD, value='string::lowercase($value.id.to_string())'),
+      ],
+    )
+
+    stmts = generate_table_sql(table)
+
+    # Untouched: bare TYPE record, VALUE clause kept verbatim.
+    assert any(
+      s
+      == 'DEFINE FIELD author ON TABLE post TYPE record VALUE string::lowercase($value.id.to_string());'
+      for s in stmts
+    )
+
+  def test_record_with_explicit_target_table_drops_matching_value(self) -> None:
+    """When `target_table` matches what `value` would have coerced to, drop VALUE."""
+    table = table_schema(
+      'post',
+      mode=TableMode.SCHEMAFULL,
+      fields=[
+        field(
+          'author',
+          FieldType.RECORD,
+          target_table='user',
+          value='type::record("user", $value)',
+        ),
+      ],
+    )
+
+    stmts = generate_table_sql(table)
+
+    assert 'DEFINE FIELD author ON TABLE post TYPE record<user>;' in stmts
+    assert not any('VALUE' in s for s in stmts)

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.13"
+version = "1.5.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes #92.

`field(name, FieldType.RECORD, value='type::record(\"user\", $value)')` was
emitting `DEFINE FIELD … TYPE record VALUE type::record(\"user\", $value)` —
bare `TYPE record` plus a coercion. SurrealDB stored the link fine, but the
type system carried no signal of *which* table the field links to, so
introspection-driven tools (Surrealist's Table Graph designer, ERD
generators, anything reading `INFO FOR TABLE`) couldn't render the
cross-table arrow.

### Behavior changes

- **Explicit** — `field(name, FieldType.RECORD, target_table='user')` now
  emits `DEFINE FIELD name … TYPE record<user>;`
  (`option<record<user>>` when `nullable=True`). No `VALUE` clause; the
  parameterized type carries the constraint.
- **Auto-detection (backward-compat)** — when `target_table=` isn't passed
  but the existing `value=` matches the canonical
  `type::record(\"X\", $value)` shape, the emitter lifts `X` into
  `target_table=X` automatically and drops the now-redundant `VALUE`
  clause. Existing schemas using the `value=` convention upgrade to the
  typed form on the next migration with zero code changes.
- Non-canonical `value=` expressions (e.g.
  `value='string::lowercase($value.id)'`) are left untouched — only the
  exact canonical shape triggers the upgrade, so any deliberate custom
  coercion keeps its `VALUE` clause.

### Touched

- `src/surql/schema/fields.py` — `target_table` kwarg,
  `_detect_target_table_from_value()`, canonical-pattern regex.
- `src/surql/schema/sql.py` — `_resolve_type_clause()`, VALUE-clause drop
  in `_generate_field_sql` (initial `DEFINE FIELD`).
- `src/surql/migration/diff.py` — same logic mirrored in `_field_to_sql`
  for incremental `ADD FIELD` diffs.
- Coverage: `tests/test_schema_sql.py::TestTypedRecordFields` (new class,
  5 cases) + 2 cases in
  `tests/test_migration_generator.py::TestAddFieldBackfillSQL`.

## Test plan

- [x] `uv run pytest --no-cov --ignore=tests/integration` — 2546 passed,
      9 skipped, 2 xfailed (+1 vs 1.5.13).
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] `uv run mypy src --strict` — clean.
- [ ] CI green on PR.