### PR TITLE
fix: 1.5.15 — drop non-deterministic timestamp from migration header (#93)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.15] - 2026-05-17
+
+### Fixed
+
+- **Migration generator emitted a wall-clock timestamp in the file docstring (#93).**
+  `generate_initial_migration` and `create_blank_migration` wrote
+  `Generated: {datetime.now(UTC).isoformat()}` into the docstring header of
+  every generated file. Sub-second precision meant regenerating an unchanged
+  schema produced a byte-different file every time — any "regen + diff against
+  the checked-in migration" CI gate (the standard reproducibility check)
+  reported spurious diffs even when no schema had changed.
+
+  Fix: drop the `Generated:` line entirely. The information was redundant —
+  the version-derived filename (`YYYYMMDD_HHMMSS_*.py`) already encodes when
+  the migration was generated, and `_migration_history.applied_at` records
+  when it was actually applied. The squash code path (`generate_squashed_migration`)
+  keeps its `Generated:` line; it's a single-purpose op whose timestamp is
+  genuinely meaningful audit data, not background CI noise.
+
+  Regression coverage: `test_generate_initial_migration_is_deterministic`.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2547 passed, 9 skipped, 2 xfailed**.
+
 ## [1.5.14] - 2026-05-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.14"
+version = "1.5.15"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.14'
+__version__ = '1.5.15'
 
 __all__ = [
   # Configuration

--- a/src/surql/migration/generator.py
+++ b/src/surql/migration/generator.py
@@ -215,7 +215,6 @@ def _generate_migration_content(
   # Generate file content
   content = f'''"""Migration: {description}
 
-Generated: {datetime.now(UTC).isoformat()}
 Author: {author}
 """
 
@@ -349,7 +348,6 @@ def create_blank_migration(
     # Generate blank template
     content = f'''"""Migration: {description}
 
-Generated: {datetime.now(UTC).isoformat()}
 Author: {author}
 """
 

--- a/tests/test_migration_generator.py
+++ b/tests/test_migration_generator.py
@@ -391,6 +391,36 @@ class TestGenerateInitialMigration:
     content = filepath.read_text()
     assert 'Custom initial setup' in content
 
+  def test_generate_initial_migration_is_deterministic(
+    self, temp_migration_dir: Path, tmp_path: Path
+  ) -> None:
+    """Regenerating the same schema twice produces byte-identical files (#93).
+
+    The version-derived filename is forced equal across the two runs via the
+    `_generate_version` patch — that's just a stable id for comparison. With
+    that pinned, the only remaining source of non-determinism is the file
+    body, which we assert is byte-identical. Pre-#93, the docstring header
+    embedded `Generated: {datetime.now(UTC).isoformat()}` so the two files
+    differed by sub-second precision on every regen.
+    """
+    tables = {
+      'user': TableDefinition(
+        name='user',
+        mode=TableMode.SCHEMAFULL,
+        fields=[FieldDefinition(name='name', type=FieldType.STRING)],
+      )
+    }
+    dir_b = tmp_path / 'b'
+    dir_b.mkdir()
+
+    with patch('surql.migration.generator._generate_version', return_value='20260102_120000'):
+      filepath_a = generate_initial_migration(temp_migration_dir, tables)
+      filepath_b = generate_initial_migration(dir_b, tables)
+
+    assert filepath_a.read_text() == filepath_b.read_text(), (
+      'migration generator emits a different file body across regens — non-deterministic header'
+    )
+
 
 class TestGenerateMigration:
   """Test suite for generate_migration function."""

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.14"
+version = "1.5.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

`generate_initial_migration` and `create_blank_migration` embedded
`Generated: {datetime.now(UTC).isoformat()}` in the migration file docstring
header. Sub-second precision meant regenerating an unchanged schema produced
a byte-different file on every run, breaking any "regen + diff against the
checked-in migration" CI reproducibility gate.

## Fix

Drop the `Generated:` line from `_generate_migration_content` and from the
`create_blank_migration` template. The information was redundant — the
version-derived filename (`YYYYMMDD_HHMMSS_*.py`) already encodes when the
file was generated, and `_migration_history.applied_at` records when it was
applied.

`generate_squashed_migration` in `surql/migration/squash.py` deliberately
keeps its `Generated:` line; squash is a one-shot op whose timestamp is
genuine audit data, not background CI noise.

## Regression coverage

New test `test_generate_initial_migration_is_deterministic` in
`TestGenerateInitialMigration` regenerates the same schema into two
directories with `_generate_version` patched to a constant id, then asserts
both files are byte-identical. Before this fix, the test would fail on the
docstring `Generated:` line.

## Verified

- `uv run ruff check src tests` — clean
- `uv run ruff format --check src tests` — clean
- `uv run mypy src --strict` — no issues
- `uv run pytest --no-cov --ignore=tests/integration` — **2547 passed, 9 skipped, 2 xfailed** (one more than 1.5.14's 2546)

## Test plan

- [x] All unit tests pass with the new regression test included
- [x] Lint + format gates clean
- [x] Strict mypy clean