### PR TITLE
feat: 1.6.0 — graph-helper WHERE filters, transaction error detection, CRUD docs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,111 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-05-17
+
+### Added
+
+- **`conditions=` parameter on graph traversal helpers.** Six graph
+  helpers — `traverse`, `traverse_with_depth`, `get_related_records`,
+  `get_outgoing_edges`, `get_incoming_edges`, and `shortest_path` —
+  now accept an optional `conditions: list[str | Operator] | None`
+  keyword. Each entry is rendered through `Query.where(...)`, matching
+  the exact shape that `query_records` already accepts; multiple
+  conditions combine with AND. Pre-1.6.0 these helpers emitted bare
+  `SELECT ... FETCH ...` with no WHERE hook, forcing any caller that
+  needed row-level isolation (multi-tenant filtering, archived-flag
+  exclusion, etc.) to roll a custom walker. The parameter is purely
+  additive — defaulting `None` leaves the emitted SurrealQL byte-for-byte
+  identical to 1.5.15. As part of the refactor, the four helpers that
+  previously emitted hand-rolled f-string SQL now route through the
+  `Query` builder so the WHERE composition is identical to the typed
+  CRUD helpers' path. Regression coverage:
+  `tests/test_query_graph.py::TestTraverseConditions` plus per-helper
+  sibling classes (46 new tests).
+
+### Fixed
+
+- **Transaction commits silently swallowed mid-batch failures.** Prior
+  to 1.6.0 `Transaction.commit()` flushed buffered statements as a
+  single `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` request through
+  the SDK's `query` method. SurrealDB v3 collapses that response to
+  `None` regardless of whether the batch succeeded OR was rolled back
+  server-side — verified against `surrealdb/surrealdb:v3.0.5` with
+  `surrealdb==2.0.0a1`. The commit helper read `None` as success, so a
+  single bad statement that triggered a rollback (type mismatch on a
+  SCHEMAFULL field, assertion failure, FK violation) was
+  indistinguishable from a clean commit. Callers saw "transaction
+  committed", looked for their writes, and found nothing.
+
+  Fix: inject a sentinel `RETURN '__txn_ok__';` statement immediately
+  before the `COMMIT TRANSACTION` line, then route the commit RPC
+  through the SDK's `query_raw` method instead of `query`. `query_raw`
+  preserves the per-statement `{status, result}` envelope; the sentinel
+  surfaces as `{'result': '__txn_ok__', 'status': 'OK'}` on success and
+  is absent on rollback (the COMMIT entry is replaced with
+  `status: 'ERR'`, `details.kind: 'Cancelled'`). The commit method now
+  inspects the envelope and raises `TransactionError` with the
+  server's per-statement explanation when any statement has
+  `status == 'ERR'` OR the sentinel is missing. State machine
+  transitions to `CANCELLED` (not `COMMITTED`) on this path.
+
+  Defensive fallback: when the underlying SDK does not expose
+  `query_raw` (older alpha versions, vendored forks), the commit falls
+  through to the prior `execute` path and logs a warning — silent
+  swallow is preserved only on SDK versions we cannot probe. The
+  module docstring and this entry document the limitation; the
+  warning string names the cause so operators can correlate it with
+  an SDK pin.
+
+  Regression coverage:
+  `tests/test_connection.py::TestTransaction::test_commit_returns_user_statement_results`,
+  `test_commit_raises_on_mid_batch_failure`,
+  `test_commit_raises_when_sentinel_absent`, and
+  `test_commit_falls_back_when_query_raw_unavailable` (8 new tests
+  across two anyio backends).
+
+### Changed
+
+- **Typed-vs-untyped CRUD documentation clarified.** Investigation
+  revealed the typed (`create_typed`, `update_typed`, `upsert_typed`,
+  `get_typed`, `query_typed`) and untyped (`create_record`,
+  `update_record`, `upsert_record`, `get_record`, `query_records`)
+  surfaces are partial duplicates with deliberate asymmetries, not
+  full aliases:
+
+  - `create_typed` / `update_typed` / `upsert_typed` differ from their
+    untyped siblings in return type only — untyped returns
+    `dict[str, Any]`, typed revalidates the response into the model
+    instance's class and returns `T`.
+  - `get_typed` is a thin alias of `get_record` (the untyped helper
+    already returns `T | None` when given a `model: type[T]`).
+  - `query_typed` is NOT a typed variant of `query_records`: the
+    former runs hand-written SurrealQL, the latter uses the `Query`
+    builder. They serve different use cases.
+
+  Module-level docstrings in both `src/surql/query/crud.py` and
+  `src/surql/query/typed.py` now carry a "when to use which" section
+  pointing at the canonical sibling and naming the asymmetries
+  explicitly. Per-function docstrings cross-reference the alternative
+  helper. No code change — both surfaces remain supported.
+
+### Verified
+
+- **Sentinel-probe assumption verified against live SurrealDB v3.0.5.**
+  Direct HTTP `/sql` shows the sentinel surfaces as
+  `{'result': '__txn_ok__', 'status': 'OK'}` on success and the
+  statement list contains `status: 'ERR'` rows on rollback. The Python
+  SDK's `query` method collapses both shapes to `None`; the SDK's
+  `query_raw` method preserves the full envelope. The commit path
+  routes through `query_raw` and is therefore observationally
+  equivalent to direct HTTP for the purposes of mid-batch error
+  detection.
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues, 81 source files.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2601 passed,
+  9 skipped, 2 xfailed** (was 2547 in 1.5.15; +54 new regression tests
+  covering the three items above).
+
 ## [1.5.15] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.5.15"
+version = "1.6.0"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.5.15'
+__version__ = '1.6.0'
 
 __all__ = [
   # Configuration

--- a/src/surql/connection/transaction.py
+++ b/src/surql/connection/transaction.py
@@ -28,6 +28,34 @@ Consequences of option (b):
   (the SDK exposes a single ``vars`` dict per request). Callers must
   choose unique parameter keys across their queued statements inside
   the same transaction block.
+
+Mid-batch error detection (1.6.0)
+=================================
+
+SurrealDB v3 collapses the SDK ``query`` method's return value to
+``None`` for batched ``BEGIN TRANSACTION; ...; COMMIT TRANSACTION;``
+requests regardless of whether the batch succeeded or any statement
+inside it rolled back the transaction. Prior to 1.6.0, the commit
+helper read that ``None`` as a success — silently swallowing
+mid-batch failures (type mismatches, assertion failures, FK violations,
+etc.). To restore observability without dropping the single-RPC
+strategy, ``commit`` now:
+
+1. Injects a sentinel ``RETURN '__txn_ok__';`` statement immediately
+   before ``COMMIT TRANSACTION`` so the server emits a recognisable
+   marker in the response envelope on success.
+2. Sends the batched statement via the SDK's ``query_raw`` method
+   instead of ``query``. ``query_raw`` preserves the per-statement
+   ``{status, result}`` envelope; ``query`` collapses it.
+3. Inspects the returned envelope: if any statement has
+   ``status == 'ERR'`` OR the sentinel value is absent from the result
+   set, the batch is considered failed, the state moves to
+   ``CANCELLED`` (not ``COMMITTED``), and a ``TransactionError`` is
+   raised with a message pointing at the per-statement error and
+   server-log inspection guidance.
+
+The sentinel and ``query_raw`` behaviours were verified against
+SurrealDB v3.0.5 (see ``CHANGES`` 1.6.0 ``### Verified``).
 """
 
 from collections.abc import AsyncIterator
@@ -43,6 +71,13 @@ from surql.connection.client import DatabaseClient
 logger = structlog.get_logger(__name__)
 
 _active_transaction: ContextVar[bool] = ContextVar('_active_transaction', default=False)
+
+# Sentinel emitted via ``RETURN '<SENTINEL>'`` immediately before the
+# ``COMMIT TRANSACTION`` line. On success SurrealDB v3 surfaces it as
+# ``{'result': '__txn_ok__', 'status': 'OK'}`` in the per-statement
+# envelope; on rollback no statement returns this value (the COMMIT
+# entry's status is ``'ERR'`` with ``details.kind == 'Cancelled'``).
+_TRANSACTION_SENTINEL: str = '__txn_ok__'
 
 
 class TransactionState(Enum):
@@ -115,14 +150,25 @@ class Transaction:
     """Commit the transaction.
 
     Flushes buffered statements as a single
-    ``BEGIN TRANSACTION; ...; COMMIT TRANSACTION;`` request.
+    ``BEGIN TRANSACTION; ...; <sentinel>; COMMIT TRANSACTION;`` request.
+
+    The sentinel (``RETURN '__txn_ok__';``) is injected immediately
+    before the ``COMMIT TRANSACTION`` line so the response envelope
+    carries a recognisable success marker. On rollback the server
+    returns per-statement ``status == 'ERR'`` entries and the sentinel
+    is absent, allowing this method to raise instead of silently
+    swallowing mid-batch failures (the pre-1.6.0 regression — see
+    module docstring).
 
     Returns:
-      The aggregate result of the batched query, or ``None`` when no
-      statements were queued.
+      The list of user-statement results extracted from the batched
+      response envelope (the ``BEGIN TRANSACTION``, sentinel, and
+      ``COMMIT TRANSACTION`` entries are stripped), or ``None`` when
+      no statements were queued.
 
     Raises:
-      TransactionError: If transaction is not active or commit fails
+      TransactionError: If transaction is not active, the commit RPC
+        raised, or the batch was rolled back server-side.
     """
     if self._state != TransactionState.ACTIVE:
       raise TransactionError(f'Cannot commit transaction in {self._state.value} state')
@@ -134,23 +180,102 @@ class Transaction:
       _active_transaction.set(False)
       return None
 
+    queued_count = len(self._statements)
     batched = 'BEGIN TRANSACTION;\n'
     for stmt in self._statements:
       batched += stmt.rstrip(';') + ';\n'
+    # Sentinel must precede COMMIT — it is the marker we look for in
+    # the response envelope to confirm success. See module docstring.
+    batched += f"RETURN '{_TRANSACTION_SENTINEL}';\n"
     batched += 'COMMIT TRANSACTION;'
 
     try:
-      self._log.info('committing_transaction', statement_count=len(self._statements))
-      result = await self._client.execute(batched, self._params or None)
-      self._state = TransactionState.COMMITTED
-      _active_transaction.set(False)
-      self._log.info('transaction_committed')
-      return result
+      self._log.info('committing_transaction', statement_count=queued_count)
+      envelope, envelope_inspectable = await self._raw_query(batched, self._params or None)
     except Exception as e:
       self._log.error('transaction_commit_failed', error=str(e))
       self._state = TransactionState.CANCELLED
       _active_transaction.set(False)
       raise TransactionError(f'Failed to commit transaction: {e}') from e
+
+    if not envelope_inspectable:
+      # Fallback path: SDK lacks ``query_raw`` so sentinel detection
+      # is impossible. Preserve the pre-1.6.0 silent-success behaviour
+      # rather than break the commit on SDK versions we cannot probe.
+      # The module docstring + CHANGES 1.6.0 ``### Verified`` warn
+      # operators that this mode is observationally weaker.
+      self._state = TransactionState.COMMITTED
+      _active_transaction.set(False)
+      self._log.warning(
+        'transaction_committed_without_sentinel_inspection',
+        statement_count=queued_count,
+        reason='SDK ``query_raw`` unavailable; mid-batch failures cannot be detected',
+      )
+      return envelope
+
+    statements = _extract_envelope_statements(envelope)
+    error_messages = _collect_envelope_errors(statements)
+    sentinel_present = any(_is_sentinel_entry(entry) for entry in statements)
+
+    if error_messages or not sentinel_present:
+      self._state = TransactionState.CANCELLED
+      _active_transaction.set(False)
+      detail = '; '.join(error_messages) if error_messages else 'sentinel marker absent'
+      self._log.error(
+        'transaction_rolled_back',
+        error_count=len(error_messages),
+        sentinel_present=sentinel_present,
+        first_error=error_messages[0] if error_messages else None,
+      )
+      raise TransactionError(
+        'Transaction failed — SurrealDB rolled back the batch; one or more '
+        'statements rejected. SurrealDB v3 batched transactions do not surface '
+        "per-statement errors via the SDK's ``query`` method, so the server "
+        'envelope was inspected directly. '
+        f'Detail: {detail}. Check server logs for the full statement trace.'
+      )
+
+    self._state = TransactionState.COMMITTED
+    _active_transaction.set(False)
+    self._log.info('transaction_committed', statement_count=queued_count)
+    # Strip the BEGIN (always first), sentinel, and COMMIT (always last)
+    # framing entries before returning, so callers see only their own
+    # statements' results.
+    return _strip_framing(statements)
+
+  async def _raw_query(self, batched: str, params: dict[str, Any] | None) -> tuple[Any, bool]:
+    """Send the batched statement via the SDK and return the raw envelope.
+
+    The SDK's ``query`` method collapses batched-transaction responses
+    to ``None`` regardless of success or failure (verified against
+    SurrealDB v3.0.5 + ``surrealdb==2.0.0a1``), so we route through
+    ``query_raw``, which preserves the per-statement
+    ``{status, result}`` envelope required for sentinel inspection.
+    Falls back to the public ``DatabaseClient.execute`` path when the
+    underlying SDK does not expose ``query_raw`` — preserves the prior
+    silent-swallow behaviour on unsupported SDK versions rather than
+    breaking the commit path.
+
+    Args:
+      batched: The full ``BEGIN ... <stmts> ... RETURN '<sentinel>'; COMMIT;``
+        string.
+      params: Optional flat ``vars`` dict shared across all queued
+        statements.
+
+    Returns:
+      ``(envelope, inspectable)`` tuple. ``inspectable=True`` means
+      the envelope came from ``query_raw`` and carries the per-statement
+      ``{status, result}`` rows the sentinel logic needs.
+      ``inspectable=False`` means we used the legacy ``execute`` path;
+      callers must skip sentinel inspection in that case (the SDK has
+      already collapsed the envelope and there is nothing to probe).
+    """
+    sdk_client = getattr(self._client, '_client', None)
+    query_raw = getattr(sdk_client, 'query_raw', None) if sdk_client is not None else None
+    if query_raw is None:
+      self._log.debug('query_raw_unavailable_falling_back_to_execute')
+      return await self._client.execute(batched, params), False
+    return await query_raw(batched, params or {}), True
 
   async def cancel(self) -> None:
     """Cancel/rollback the transaction.
@@ -262,3 +387,86 @@ async def transaction(client: DatabaseClient) -> AsyncIterator[Transaction]:
     if txn.is_active:
       await txn.cancel()
     raise
+
+
+# ---------------------------------------------------------------------------
+# Envelope inspection helpers (Item 2 — 1.6.0)
+# ---------------------------------------------------------------------------
+
+
+def _extract_envelope_statements(envelope: Any) -> list[Any]:
+  """Normalise the SDK ``query_raw`` envelope into a flat statement list.
+
+  SurrealDB v3 returns the result envelope in one of two shapes:
+
+  - ``{'id': <req-id>, 'result': [<per-stmt>, ...]}`` — the standard
+    WebSocket-RPC shape returned by ``surrealdb.AsyncSurreal.query_raw``.
+  - ``[<per-stmt>, ...]`` — the HTTP ``/sql`` shape (used by some
+    mocks and older SDK paths).
+
+  Returns an empty list when the envelope is anything else (e.g.
+  ``None`` from the SDK-fallback path on an unsupported SDK version).
+  Empty list disables sentinel detection and matches the pre-1.6.0
+  behaviour for that edge case.
+  """
+  if isinstance(envelope, dict) and isinstance(envelope.get('result'), list):
+    return list(envelope['result'])
+  if isinstance(envelope, list):
+    return list(envelope)
+  return []
+
+
+def _collect_envelope_errors(statements: list[Any]) -> list[str]:
+  """Return human-readable error messages for any ``status == 'ERR'`` entries.
+
+  Each error entry is expected to be a dict with a ``'result'`` field
+  carrying the server-supplied error string (e.g.
+  ``"Couldn't coerce value for field `age` of `bar:2`..."``). The
+  ``COMMIT TRANSACTION`` entry's ``Cancelled`` status is intentionally
+  surfaced here as well — it tells the caller the rollback fired.
+  """
+  errors: list[str] = []
+  for entry in statements:
+    if not isinstance(entry, dict):
+      continue
+    if entry.get('status') != 'ERR':
+      continue
+    message = entry.get('result')
+    if isinstance(message, str) and message:
+      errors.append(message)
+    else:
+      errors.append(repr(entry))
+  return errors
+
+
+def _is_sentinel_entry(entry: Any) -> bool:
+  """Check whether a per-statement envelope entry carries the sentinel value."""
+  if not isinstance(entry, dict):
+    return False
+  if entry.get('status') != 'OK':
+    return False
+  return entry.get('result') == _TRANSACTION_SENTINEL
+
+
+def _strip_framing(statements: list[Any]) -> list[Any]:
+  """Strip the BEGIN, sentinel, and COMMIT framing entries from the envelope.
+
+  The leading entry is always the ``BEGIN TRANSACTION`` ack, the
+  trailing entry is the ``COMMIT TRANSACTION`` ack, and the
+  second-to-last entry is the sentinel ``RETURN '__txn_ok__'`` result.
+  Callers should see only the results of their own queued statements.
+  Defensively handles short envelopes (mocks may return a shorter list).
+  """
+  filtered = [entry for entry in statements if not _is_sentinel_entry(entry)]
+  # Drop a leading no-op (BEGIN) entry: ``{'result': None, 'status': 'OK'}``
+  # or any None-result OK row at index 0. Same for the trailing COMMIT ack.
+  if filtered and _is_framing_ack(filtered[0]):
+    filtered = filtered[1:]
+  if filtered and _is_framing_ack(filtered[-1]):
+    filtered = filtered[:-1]
+  return filtered
+
+
+def _is_framing_ack(entry: Any) -> bool:
+  """An ack row is ``{'status': 'OK', 'result': None}``."""
+  return isinstance(entry, dict) and entry.get('status') == 'OK' and entry.get('result') is None

--- a/src/surql/query/crud.py
+++ b/src/surql/query/crud.py
@@ -2,6 +2,28 @@
 
 This module provides convenient async functions for common database operations
 with type safety through Pydantic models.
+
+Untyped vs typed — when to use which
+====================================
+
+The helpers here (``create_record``, ``update_record``,
+``upsert_record``) return ``dict[str, Any]`` after SDK
+normalisation, and ``get_record`` / ``query_records`` already accept
+a ``model: type[T]`` argument and return typed instances when given
+one. They are the right call when you want the raw dict shape, are
+working across heterogeneous record types, or are inside the builder
+flow.
+
+The parallel module :mod:`surql.query.typed` provides
+``create_typed`` / ``update_typed`` / ``upsert_typed`` which differ
+in return type only: they take a concrete
+:class:`~pydantic.BaseModel` instance and revalidate the response
+through ``data.__class__``, returning ``T`` instead of
+``dict[str, Any]``. Prefer the typed module when the call site
+already has the concrete model in hand and the strict-mypy gates
+want a typed handle. See ``surql/query/typed.py`` for the full
+asymmetry table (notably, ``query_typed`` runs raw SurrealQL — it is
+NOT a typed variant of :func:`query_records`).
 """
 
 from __future__ import annotations

--- a/src/surql/query/graph.py
+++ b/src/surql/query/graph.py
@@ -21,6 +21,7 @@ from surql.connection.context import get_db
 from surql.query.builder import Query
 from surql.query.executor import fetch_all
 from surql.query.graph_query import GraphQuery, _extract_graph_result
+from surql.types.operators import Operator
 from surql.types.record_id import RecordID
 
 # Re-export GraphQuery for backward compatibility
@@ -366,6 +367,7 @@ async def traverse[T: BaseModel](
   start: str | RecordID[Any],
   path: str,
   model: type[T],
+  conditions: list[str | Operator] | None = None,
   client: DatabaseClient | None = None,
 ) -> list[T]:
   """Navigate relationships using graph traversal.
@@ -374,6 +376,12 @@ async def traverse[T: BaseModel](
     start: Starting record ID
     path: Traversal path (e.g., '->likes->post', '<-follows<-user')
     model: Pydantic model class for deserialization
+    conditions: Optional WHERE conditions appended to the generated query.
+      Each entry is rendered via :meth:`Query.where`, so raw SurrealQL
+      strings and :class:`Operator` instances are both accepted. Multiple
+      conditions combine with AND. Mirrors the shape accepted by
+      :func:`~surql.query.crud.query_records`. Used for multi-tenant row
+      filtering and any other row-level isolation a caller needs.
     client: Database client. If None, uses context client.
 
   Returns:
@@ -391,12 +399,21 @@ async def traverse[T: BaseModel](
 
     >>> # Multi-hop: followers of followers
     >>> fof = await traverse('user:alice', '<-follows<-user<-follows<-user', User)
+
+    >>> # Tenant-scoped traversal
+    >>> from surql.types.operators import eq
+    >>> posts = await traverse(
+    ...     'user:alice', '->likes->post', Post,
+    ...     conditions=[eq('tenant_id', 'acme')],
+    ... )
   """
   start_str = str(start) if isinstance(start, RecordID) else start
 
   logger.info('traversing_graph', start=start_str, path=path)
 
   query = Query[T]().select().from_table(start_str).traverse(path)
+  for cond in conditions or []:
+    query = query.where(cond)
 
   return await fetch_all(query, model, client)
 
@@ -408,6 +425,7 @@ async def traverse_with_depth[T: BaseModel](
   direction: str = 'out',
   depth: int | None = None,
   model: type[T] | None = None,
+  conditions: list[str | Operator] | None = None,
   client: DatabaseClient | None = None,
 ) -> list[T] | list[dict[str, Any]]:
   """Navigate relationships with optional depth limit.
@@ -419,6 +437,10 @@ async def traverse_with_depth[T: BaseModel](
     direction: Traversal direction ('out', 'in', 'both')
     depth: Maximum depth (None for unlimited)
     model: Optional Pydantic model for deserialization
+    conditions: Optional WHERE conditions appended to the generated query.
+      Same shape as :func:`~surql.query.crud.query_records` — accepts raw
+      SurrealQL strings and :class:`Operator` instances; multiple entries
+      combine with AND.
     client: Database client. If None, uses context client.
 
   Returns:
@@ -452,10 +474,12 @@ async def traverse_with_depth[T: BaseModel](
   logger.info('traversing_with_depth', start=start_str, path=path, depth=depth)
 
   if model:
-    return await traverse(start_str, path, model, client)
+    return await traverse(start_str, path, model, conditions=conditions, client=client)
   else:
     # Return raw results
     query: Query[Any] = Query().select().from_table(start_str).traverse(path)
+    for cond in conditions or []:
+      query = query.where(cond)
     db = client or get_db()
     result = await db.execute(query.to_surql())
 
@@ -567,6 +591,7 @@ async def get_outgoing_edges[T: BaseModel](
   record: str | RecordID[Any],
   edge_table: str,
   model: type[T] | None = None,
+  conditions: list[str | Operator] | None = None,
   client: DatabaseClient | None = None,
 ) -> list[T] | list[dict[str, Any]]:
   """Get all outgoing edges from a record.
@@ -575,6 +600,10 @@ async def get_outgoing_edges[T: BaseModel](
     record: Source record ID
     edge_table: Edge table name
     model: Optional Pydantic model for deserialization
+    conditions: Optional WHERE conditions appended to the generated query.
+      Each entry may be a raw SurrealQL string or an :class:`Operator`
+      instance; multiple entries combine with AND. Same shape as
+      :func:`~surql.query.crud.query_records`.
     client: Database client. If None, uses context client.
 
   Returns:
@@ -583,15 +612,23 @@ async def get_outgoing_edges[T: BaseModel](
   Examples:
     >>> # Get all likes from user
     >>> likes = await get_outgoing_edges('user:alice', 'likes')
+
+    >>> # Tenant-scoped variant
+    >>> from surql.types.operators import eq
+    >>> likes = await get_outgoing_edges(
+    ...     'user:alice', 'likes', conditions=[eq('tenant_id', 'acme')],
+    ... )
   """
   record_str = str(record) if isinstance(record, RecordID) else record
 
   logger.info('fetching_outgoing_edges', record=record_str, edge_table=edge_table)
 
-  sql = f'SELECT * FROM {record_str}->{edge_table}'
+  query: Query[Any] = Query().select().from_table(f'{record_str}->{edge_table}')
+  for cond in conditions or []:
+    query = query.where(cond)
 
   db = client or get_db()
-  result = await db.execute(sql)
+  result = await db.execute(query.to_surql())
 
   # Extract data
   data: list[Any] = []
@@ -608,6 +645,7 @@ async def get_incoming_edges[T: BaseModel](
   record: str | RecordID[Any],
   edge_table: str,
   model: type[T] | None = None,
+  conditions: list[str | Operator] | None = None,
   client: DatabaseClient | None = None,
 ) -> list[T] | list[dict[str, Any]]:
   """Get all incoming edges to a record.
@@ -616,6 +654,10 @@ async def get_incoming_edges[T: BaseModel](
     record: Target record ID
     edge_table: Edge table name
     model: Optional Pydantic model for deserialization
+    conditions: Optional WHERE conditions appended to the generated query.
+      Each entry may be a raw SurrealQL string or an :class:`Operator`
+      instance; multiple entries combine with AND. Same shape as
+      :func:`~surql.query.crud.query_records`.
     client: Database client. If None, uses context client.
 
   Returns:
@@ -624,6 +666,12 @@ async def get_incoming_edges[T: BaseModel](
   Examples:
     >>> # Get all follows to user
     >>> follows = await get_incoming_edges('user:alice', 'follows')
+
+    >>> # Tenant-scoped variant
+    >>> from surql.types.operators import eq
+    >>> follows = await get_incoming_edges(
+    ...     'user:alice', 'follows', conditions=[eq('tenant_id', 'acme')],
+    ... )
   """
   record_str = str(record) if isinstance(record, RecordID) else record
 
@@ -631,10 +679,12 @@ async def get_incoming_edges[T: BaseModel](
 
   # v3-safe form: anchor record on the left (`record<-edge`), not the
   # v2 `<-edge<-record` which v3 rejects. See Oneiriq/surql-py#33.
-  sql = f'SELECT * FROM {record_str}<-{edge_table}'
+  query: Query[Any] = Query().select().from_table(f'{record_str}<-{edge_table}')
+  for cond in conditions or []:
+    query = query.where(cond)
 
   db = client or get_db()
-  result = await db.execute(sql)
+  result = await db.execute(query.to_surql())
 
   # Extract data
   data: list[Any] = []
@@ -653,6 +703,7 @@ async def get_related_records[T: BaseModel](
   target_table: str,
   direction: str = 'out',
   model: type[T] | None = None,
+  conditions: list[str | Operator] | None = None,
   client: DatabaseClient | None = None,
 ) -> list[T] | list[dict[str, Any]]:
   """Get records related through an edge.
@@ -663,6 +714,10 @@ async def get_related_records[T: BaseModel](
     target_table: Related records table name
     direction: Relationship direction ('out' or 'in')
     model: Optional Pydantic model for deserialization
+    conditions: Optional WHERE conditions appended to the generated query.
+      Each entry may be a raw SurrealQL string or an :class:`Operator`
+      instance; multiple entries combine with AND. Same shape as
+      :func:`~surql.query.crud.query_records`.
     client: Database client. If None, uses context client.
 
   Returns:
@@ -674,6 +729,13 @@ async def get_related_records[T: BaseModel](
 
     >>> # Get all users who liked a post
     >>> users = await get_related_records('post:123', 'likes', 'user', 'in', User)
+
+    >>> # Tenant-scoped variant
+    >>> from surql.types.operators import eq
+    >>> posts = await get_related_records(
+    ...     'user:alice', 'likes', 'post', 'out', Post,
+    ...     conditions=[eq('tenant_id', 'acme')],
+    ... )
   """
   record_str = str(record) if isinstance(record, RecordID) else record
 
@@ -689,11 +751,13 @@ async def get_related_records[T: BaseModel](
     raise ValueError(f'Invalid direction: {direction}. Must be "out" or "in"')
 
   if model:
-    return await traverse(record_str, path, model, client)
+    return await traverse(record_str, path, model, conditions=conditions, client=client)
   else:
-    sql = f'SELECT * FROM {record_str}{path}'
+    query: Query[Any] = Query().select().from_table(f'{record_str}{path}')
+    for cond in conditions or []:
+      query = query.where(cond)
     db = client or get_db()
-    result = await db.execute(sql)
+    result = await db.execute(query.to_surql())
 
     # Extract data
     if (
@@ -765,6 +829,7 @@ async def shortest_path(
   to_record: str | RecordID[Any],
   edge_table: str,
   max_depth: int = 10,
+  conditions: list[str | Operator] | None = None,
   client: DatabaseClient | None = None,
 ) -> list[dict[str, Any]]:
   """Find shortest path between two records.
@@ -777,6 +842,11 @@ async def shortest_path(
     to_record: Target record ID
     edge_table: Edge table to traverse
     max_depth: Maximum path depth to search
+    conditions: Optional WHERE conditions appended to the generated query.
+      Each entry may be a raw SurrealQL string or an :class:`Operator`
+      instance; multiple entries combine with AND. The mandatory
+      ``id = <to_record>`` predicate is always included; supplied
+      conditions widen the filter (e.g. tenant scoping).
     client: Database client. If None, uses context client.
 
   Returns:
@@ -784,6 +854,13 @@ async def shortest_path(
 
   Examples:
     >>> path = await shortest_path('user:alice', 'user:charlie', 'follows', max_depth=5)
+
+    >>> # Tenant-scoped variant
+    >>> from surql.types.operators import eq
+    >>> path = await shortest_path(
+    ...     'user:alice', 'user:charlie', 'follows',
+    ...     conditions=[eq('tenant_id', 'acme')],
+    ... )
   """
   from_str = str(from_record) if isinstance(from_record, RecordID) else from_record
   to_str = str(to_record) if isinstance(to_record, RecordID) else to_record
@@ -795,14 +872,14 @@ async def shortest_path(
   # hops. See Oneiriq/surql-py#34.
   for depth in range(1, max_depth + 1):
     hops = ''.join(f'->{edge_table}->?' for _ in range(depth))
-    sql = f"""
-    SELECT * FROM {from_str}{hops}
-    WHERE id = {to_str}
-    LIMIT 1
-    """
+    query: Query[Any] = (
+      Query().select().from_table(f'{from_str}{hops}').where(f'id = {to_str}').limit(1)
+    )
+    for cond in conditions or []:
+      query = query.where(cond)
 
     db = client or get_db()
-    result = await db.execute(sql)
+    result = await db.execute(query.to_surql())
 
     if result:
       # Found path at this depth

--- a/src/surql/query/typed.py
+++ b/src/surql/query/typed.py
@@ -1,8 +1,44 @@
 """Typed CRUD operations returning validated Pydantic model instances.
 
-This module wraps the lower-level CRUD functions from surql.query.crud
+This module wraps the lower-level CRUD functions from ``surql.query.crud``
 with generic type annotations so callers receive fully validated Pydantic
 models instead of raw dictionaries.
+
+Typed vs untyped — when to use which
+====================================
+
+The untyped helpers in :mod:`surql.query.crud` (``create_record``,
+``update_record``, ``upsert_record``) accept any ``BaseModel`` or
+``dict`` and return ``dict[str, Any]`` — the raw SurrealDB response
+shape after normalisation. They are appropriate when callers want to
+inspect the raw envelope, build their own ad-hoc validation, or work
+across heterogeneous record types.
+
+The typed helpers here (``create_typed``, ``update_typed``,
+``upsert_typed``) take a concrete :class:`~pydantic.BaseModel`
+instance, perform the same CRUD, then ``model_validate`` the response
+back into the same model type. They are the right call when:
+
+- the call site already knows the concrete model type,
+- callers want the typed return value (``T``, not ``dict``) without
+  re-validating themselves, and
+- the strict-mypy gates on the consumer want a typed handle, not a
+  dict-of-Any.
+
+Lightweight asymmetries (intentional, documented here):
+
+- :func:`get_typed` is a thin alias around
+  :func:`~surql.query.crud.get_record` — the untyped helper already
+  returns ``T | None`` (it takes a model class), so the typed variant
+  exists only for naming symmetry with the rest of the typed surface.
+  Both behave identically.
+- :func:`query_typed` runs a raw SurrealQL string and validates each
+  row. It is NOT a typed variant of
+  :func:`~surql.query.crud.query_records` — the latter uses the
+  :class:`~surql.query.builder.Query` builder with ``conditions=``,
+  ``order_by=``, ``limit=``, etc. Use ``query_records`` when you want
+  the builder; use ``query_typed`` when you want to hand-write the
+  SurrealQL.
 """
 
 from __future__ import annotations
@@ -34,6 +70,14 @@ async def create_typed(
 ) -> T:
   """Create a record from a Pydantic model and return a validated instance.
 
+  Differs from :func:`~surql.query.crud.create_record` in the return
+  type only: ``create_record`` returns ``dict[str, Any]`` (the raw
+  normalised response), while this helper revalidates the response
+  through ``data.__class__`` and returns a typed instance. Prefer
+  this helper when the call site already has the concrete model type
+  in hand; prefer ``create_record`` when working across heterogeneous
+  rows or when you want the raw dict shape.
+
   Args:
     table: Table name to insert into
     data: Pydantic model instance with the record data
@@ -64,6 +108,13 @@ async def get_typed(
 ) -> T | None:
   """Fetch a single record and validate it into the given model type.
 
+  Thin alias around :func:`~surql.query.crud.get_record`. The untyped
+  helper already takes a ``model: type[T]`` argument and returns
+  ``T | None``; this wrapper exists for naming symmetry with the rest
+  of the typed surface. Behaviour is identical — either is fine,
+  prefer ``get_record`` if you want to stay inside ``surql.query.crud``
+  for all CRUD calls.
+
   Args:
     table: Table name
     record_id: Record identifier (without the table prefix)
@@ -92,6 +143,21 @@ async def query_typed(
   params: dict[str, Any] | None = None,
 ) -> list[T]:
   """Execute a raw SurrealQL query and validate each result row.
+
+  NOT a typed variant of :func:`~surql.query.crud.query_records` —
+  the two helpers are intentionally different:
+
+  - ``query_records`` uses the :class:`~surql.query.builder.Query`
+    builder; pass ``conditions=``, ``order_by=``, ``limit=``, etc.
+    and SurrealQL is generated for you. Returns typed instances.
+  - ``query_typed`` (here) takes a hand-written SurrealQL string
+    plus optional positional ``$``-prefixed parameters and validates
+    each returned row against ``model_class``. Returns typed instances.
+
+  Use the builder when the query shape fits the builder API; reach
+  for ``query_typed`` when you need a SurrealQL construct the builder
+  doesn't model (graph paths inside subqueries, custom function
+  calls, INFO queries, etc.).
 
   Args:
     surql: SurrealQL query string
@@ -126,6 +192,12 @@ async def update_typed(
 ) -> T:
   """Update a record from a Pydantic model and return the validated result.
 
+  Differs from :func:`~surql.query.crud.update_record` in the return
+  type only: ``update_record`` returns ``dict[str, Any]``; this
+  helper revalidates the response into ``data.__class__``. Prefer
+  this when the call site has the concrete model type; prefer
+  ``update_record`` for the raw dict shape.
+
   Args:
     table: Table name
     record_id: Record identifier (without the table prefix)
@@ -157,6 +229,11 @@ async def upsert_typed(
   """Upsert a record from a Pydantic model and return the validated result.
 
   Creates the record if it does not exist, or replaces it if it does.
+  Differs from :func:`~surql.query.crud.upsert_record` in the return
+  type only: ``upsert_record`` returns ``dict[str, Any]``; this
+  helper revalidates the response into ``data.__class__``. Prefer
+  this when the call site has the concrete model type; prefer
+  ``upsert_record`` for the raw dict shape.
 
   Args:
     table: Table name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,9 @@ def mock_surreal_client() -> Mock:
   client.use = AsyncMock()
   client.close = AsyncMock()
   client.query = AsyncMock(return_value=[{'result': []}])
+  # query_raw returns the full envelope; default to an empty success so
+  # transaction commits in unrelated tests don't trip the sentinel check.
+  client.query_raw = AsyncMock(return_value={'result': [{'result': '__txn_ok__', 'status': 'OK'}]})
   client.select = AsyncMock(return_value=[])
   client.create = AsyncMock(return_value={'id': 'user:123'})
   client.update = AsyncMock(return_value={'id': 'user:123'})

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -596,13 +596,18 @@ class TestTransaction:
     assert txn.is_active is False
 
     # Buffered statements must be flushed as a single batched query
-    # wrapped in BEGIN TRANSACTION ... COMMIT TRANSACTION.
-    mock_db_client._client.query.assert_called_once()
-    batched = mock_db_client._client.query.call_args.args[0]
+    # wrapped in BEGIN TRANSACTION ... COMMIT TRANSACTION. As of 1.6.0
+    # the commit RPC is routed via the SDK's ``query_raw`` method
+    # (preserves the per-statement envelope required for sentinel
+    # inspection — see ``transaction.py`` module docstring).
+    mock_db_client._client.query_raw.assert_called_once()
+    batched = mock_db_client._client.query_raw.call_args.args[0]
     assert batched.startswith('BEGIN TRANSACTION;')
     assert batched.rstrip().endswith('COMMIT TRANSACTION;')
     assert 'CREATE user:alice' in batched
     assert 'CREATE user:bob' in batched
+    # Sentinel marker is injected immediately before COMMIT.
+    assert "RETURN '__txn_ok__';" in batched
 
   @pytest.mark.anyio
   async def test_commit_not_active(self, mock_db_client: DatabaseClient) -> None:
@@ -616,12 +621,14 @@ class TestTransaction:
 
   @pytest.mark.anyio
   async def test_commit_failure(self, mock_db_client: DatabaseClient) -> None:
-    """Test transaction commit failure."""
+    """Test transaction commit failure when the RPC itself raises."""
     txn = Transaction(mock_db_client)
     await txn.begin()
     await txn.execute('CREATE user:alice')
 
-    mock_db_client._client.query = AsyncMock(side_effect=Exception('Commit failed'))
+    # The 1.6.0 commit path routes through ``query_raw``; patch that
+    # mock to simulate a network/RPC failure.
+    mock_db_client._client.query_raw = AsyncMock(side_effect=Exception('Commit failed'))
 
     with pytest.raises(TransactionError):
       await txn.commit()
@@ -702,9 +709,11 @@ class TestTransaction:
       await txn.execute('UPDATE user:alice SET x = 1')
       await txn.execute('UPDATE user:bob   SET x = 2')
 
-    # Exactly one RPC on the wire, wrapped in BEGIN/COMMIT.
-    assert mock_db_client._client.query.call_count == 1
-    batched = mock_db_client._client.query.call_args.args[0]
+    # Exactly one RPC on the wire, wrapped in BEGIN/COMMIT. The
+    # commit path uses ``query_raw`` (1.6.0+) instead of ``query`` so
+    # the SDK does not collapse the per-statement envelope.
+    assert mock_db_client._client.query_raw.call_count == 1
+    batched = mock_db_client._client.query_raw.call_args.args[0]
     assert batched.count('BEGIN TRANSACTION') == 1
     assert batched.count('COMMIT TRANSACTION') == 1
 
@@ -719,8 +728,160 @@ class TestTransaction:
     await txn.execute('UPDATE user:bob   SET name = $n2', {'n2': 'Bob'})
     await txn.commit()
 
-    params = mock_db_client._client.query.call_args.args[1]
+    params = mock_db_client._client.query_raw.call_args.args[1]
     assert params == {'n1': 'Alice', 'n2': 'Bob'}
+
+  @pytest.mark.anyio
+  async def test_commit_returns_user_statement_results(
+    self, mock_db_client: DatabaseClient
+  ) -> None:
+    """1.6.0: commit returns per-statement user results, framing stripped.
+
+    The SDK envelope is shaped
+    ``{'result': [BEGIN-ack, stmt1, stmt2, sentinel, COMMIT-ack]}``.
+    Callers should see only ``[stmt1, stmt2]`` — the BEGIN, sentinel,
+    and COMMIT entries are framing.
+    """
+    txn = Transaction(mock_db_client)
+    mock_db_client._client.query_raw = AsyncMock(
+      return_value={
+        'id': 'req-1',
+        'result': [
+          {'result': None, 'status': 'OK'},  # BEGIN ack
+          {'result': [{'id': 'user:alice'}], 'status': 'OK'},
+          {'result': [{'id': 'user:bob'}], 'status': 'OK'},
+          {'result': '__txn_ok__', 'status': 'OK'},  # sentinel
+          {'result': None, 'status': 'OK'},  # COMMIT ack
+        ],
+      }
+    )
+
+    await txn.begin()
+    await txn.execute('CREATE user:alice')
+    await txn.execute('CREATE user:bob')
+    result = await txn.commit()
+
+    assert txn.state == TransactionState.COMMITTED
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]['result'] == [{'id': 'user:alice'}]
+    assert result[1]['result'] == [{'id': 'user:bob'}]
+
+  @pytest.mark.anyio
+  async def test_commit_raises_on_mid_batch_failure(self, mock_db_client: DatabaseClient) -> None:
+    """1.6.0: mid-batch errors no longer silently succeed.
+
+    Pre-1.6.0, the SDK's ``query`` method collapsed both success and
+    failure to ``None`` for batched ``BEGIN ... COMMIT`` requests, so
+    a single bad statement that triggered a server-side rollback was
+    indistinguishable from a clean commit. ``commit`` now inspects
+    the per-statement envelope returned by ``query_raw`` and raises
+    ``TransactionError`` when the rollback marker (``status == 'ERR'``)
+    appears.
+    """
+    txn = Transaction(mock_db_client)
+    # Simulate the v3.0.5 envelope for a batch that failed because
+    # statement 2 violated a SCHEMAFULL type constraint.
+    mock_db_client._client.query_raw = AsyncMock(
+      return_value={
+        'id': 'req-2',
+        'result': [
+          {'result': None, 'status': 'OK'},  # BEGIN ack
+          {
+            'details': {'kind': 'NotExecuted'},
+            'kind': 'Query',
+            'result': 'The query was not executed due to a failed transaction',
+            'status': 'ERR',
+          },
+          {
+            'kind': 'Internal',
+            'result': (
+              "Couldn't coerce value for field `age` of `bar:2`: "
+              "Expected `int` but found `'not_an_int'`"
+            ),
+            'status': 'ERR',
+          },
+          {
+            'details': {'kind': 'Cancelled'},
+            'kind': 'Query',
+            'result': 'The query was not executed due to a cancelled transaction',
+            'status': 'ERR',
+          },
+        ],
+      }
+    )
+
+    await txn.begin()
+    await txn.execute('CREATE bar:1 SET age = 10')
+    await txn.execute("CREATE bar:2 SET age = 'not_an_int'")
+
+    with pytest.raises(TransactionError) as exc_info:
+      await txn.commit()
+
+    # The error must mention the server's per-statement explanation
+    # so operators can act on it directly.
+    msg = str(exc_info.value)
+    assert 'SurrealDB rolled back the batch' in msg
+    assert 'Couldn' in msg and 'coerce value' in msg
+    # State machine transitions to CANCELLED (not COMMITTED) on rollback.
+    assert txn.state == TransactionState.CANCELLED
+
+  @pytest.mark.anyio
+  async def test_commit_raises_when_sentinel_absent(self, mock_db_client: DatabaseClient) -> None:
+    """Sentinel-absent envelope is treated as a failure even with no ERR rows.
+
+    Defensive: if a future SurrealDB version emits a degenerate
+    envelope (no ERR rows AND no sentinel), the commit must not be
+    treated as a silent success. The error message names the missing
+    marker so operators know what to inspect.
+    """
+    txn = Transaction(mock_db_client)
+    mock_db_client._client.query_raw = AsyncMock(
+      return_value={
+        'id': 'req-3',
+        'result': [
+          {'result': None, 'status': 'OK'},
+          {'result': [{'id': 'user:x'}], 'status': 'OK'},
+          # No sentinel, no ERR — should still be flagged.
+          {'result': None, 'status': 'OK'},
+        ],
+      }
+    )
+
+    await txn.begin()
+    await txn.execute('CREATE user:x')
+
+    with pytest.raises(TransactionError) as exc_info:
+      await txn.commit()
+
+    assert 'sentinel marker absent' in str(exc_info.value)
+    assert txn.state == TransactionState.CANCELLED
+
+  @pytest.mark.anyio
+  async def test_commit_falls_back_when_query_raw_unavailable(
+    self, mock_db_client: DatabaseClient
+  ) -> None:
+    """Older SDKs lacking ``query_raw`` fall through to ``execute``.
+
+    The commit path checks for ``query_raw`` on the SDK client; when
+    absent it routes through ``DatabaseClient.execute`` (the
+    pre-1.6.0 path). In that mode sentinel inspection is skipped —
+    the prior silent-swallow behaviour is preserved rather than
+    breaking the commit. This guards against pinning surql-py to an
+    SDK upgrade that lags.
+    """
+    # Strip ``query_raw`` from the SDK mock to simulate an SDK that
+    # hasn't shipped the method yet.
+    del mock_db_client._client.query_raw
+
+    txn = Transaction(mock_db_client)
+    await txn.begin()
+    await txn.execute('CREATE user:alice')
+    # Should not raise; falls through to execute and returns its
+    # collapsed result (the default mock returns ``[{'result': []}]``).
+    await txn.commit()
+
+    assert txn.state == TransactionState.COMMITTED
 
   @pytest.mark.anyio
   async def test_duplicate_param_keys_rejected(self, mock_db_client: DatabaseClient) -> None:
@@ -741,11 +902,13 @@ class TestTransaction:
     await txn.begin()
     await txn.execute('CREATE user:alice')
     mock_db_client._client.query.reset_mock()
+    mock_db_client._client.query_raw.reset_mock()
 
     await txn.cancel()
 
     # Nothing was sent to the server, and the buffer is empty.
     mock_db_client._client.query.assert_not_called()
+    mock_db_client._client.query_raw.assert_not_called()
     assert txn._statements == []
     assert txn.state == TransactionState.CANCELLED
 

--- a/tests/test_query_graph.py
+++ b/tests/test_query_graph.py
@@ -1588,3 +1588,451 @@ class TestComputeDegree:
 
     assert degree['total'] == 2
     assert mock_db_client.execute.call_count == 2
+
+
+# =============================================================================
+# 1.6.0 — `conditions=` parameter on graph helpers
+# =============================================================================
+#
+# These tests cover the additive ``conditions=`` keyword added to:
+#   - traverse
+#   - traverse_with_depth
+#   - get_outgoing_edges
+#   - get_incoming_edges
+#   - get_related_records
+#   - shortest_path
+#
+# Each helper is validated for three properties:
+#   (a) default behaviour unchanged when ``conditions`` is omitted or None
+#       (no WHERE clause appears in the emitted SurrealQL),
+#   (b) a single condition is appended verbatim as ``WHERE (...)`` via
+#       ``Query.where(...)``,
+#   (c) multiple conditions combine with AND (mirrors how
+#       ``query_records`` accepts the same shape).
+#
+# Why this matters: pre-1.6.0 the graph helpers emitted bare
+# ``SELECT ... FETCH ...`` with no WHERE hook, so multi-tenant
+# consumers couldn't use them without rolling a custom walker.
+
+
+def _emitted_sql(mock_client) -> str:
+  """Return the SurrealQL string passed to the most recent ``execute`` call."""
+  assert mock_client.execute.await_count > 0
+  return mock_client.execute.await_args.args[0]
+
+
+class TestTraverseConditions:
+  """1.6.0: ``conditions=`` on traverse()."""
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause(self, mock_db_client):
+    """Default (no conditions) emits the same SurrealQL as before."""
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse('user:alice', '->likes->post', Post, client=mock_db_client)
+
+    sql = _emitted_sql(mock_db_client)
+    assert 'WHERE' not in sql
+
+  @pytest.mark.anyio
+  async def test_single_operator_appends_where(self, mock_db_client):
+    """Single ``eq(...)`` operator appends a WHERE clause."""
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse(
+      'user:alice',
+      '->likes->post',
+      Post,
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert "WHERE (tenant_id = 'acme')" in sql
+
+  @pytest.mark.anyio
+  async def test_multiple_conditions_combine_with_and(self, mock_db_client):
+    """Multiple conditions chain as ``WHERE (a) AND (b)``."""
+    from surql.types.operators import eq, gt
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse(
+      'user:alice',
+      '->likes->post',
+      Post,
+      conditions=[eq('tenant_id', 'acme'), gt('score', 5)],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert "tenant_id = 'acme'" in sql
+    assert 'score > 5' in sql
+    assert ' AND ' in sql
+
+  @pytest.mark.anyio
+  async def test_raw_string_condition_passthrough(self, mock_db_client):
+    """Raw SurrealQL strings are passed through unchanged."""
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse(
+      'user:alice',
+      '->likes->post',
+      Post,
+      conditions=['archived = false'],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert 'WHERE (archived = false)' in sql
+
+
+class TestTraverseWithDepthConditions:
+  """1.6.0: ``conditions=`` on traverse_with_depth()."""
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause_typed(self, mock_db_client):
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse_with_depth(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      depth=1,
+      model=Post,
+      client=mock_db_client,
+    )
+
+    assert 'WHERE' not in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause_untyped(self, mock_db_client):
+    """No-model code path (returns raw dicts) also stays clean by default."""
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse_with_depth(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      depth=1,
+      model=None,
+      client=mock_db_client,
+    )
+
+    assert 'WHERE' not in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_single_condition_typed(self, mock_db_client):
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse_with_depth(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      depth=1,
+      model=Post,
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    assert "WHERE (tenant_id = 'acme')" in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_single_condition_untyped(self, mock_db_client):
+    """Conditions also flow through the no-model code path."""
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse_with_depth(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      depth=1,
+      model=None,
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    assert "WHERE (tenant_id = 'acme')" in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_multiple_conditions_combine_with_and(self, mock_db_client):
+    from surql.types.operators import eq, gt
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await traverse_with_depth(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      depth=1,
+      model=Post,
+      conditions=[eq('tenant_id', 'acme'), gt('score', 5)],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert "tenant_id = 'acme'" in sql
+    assert 'score > 5' in sql
+    assert ' AND ' in sql
+
+
+class TestGetOutgoingEdgesConditions:
+  """1.6.0: ``conditions=`` on get_outgoing_edges()."""
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause(self, mock_db_client):
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_outgoing_edges('user:alice', 'likes', client=mock_db_client)
+
+    assert 'WHERE' not in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_single_condition(self, mock_db_client):
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_outgoing_edges(
+      'user:alice',
+      'likes',
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    assert "WHERE (tenant_id = 'acme')" in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_multiple_conditions_combine_with_and(self, mock_db_client):
+    from surql.types.operators import eq, gt
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_outgoing_edges(
+      'user:alice',
+      'likes',
+      conditions=[eq('tenant_id', 'acme'), gt('weight', 0)],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert "tenant_id = 'acme'" in sql
+    assert 'weight > 0' in sql
+    assert ' AND ' in sql
+
+
+class TestGetIncomingEdgesConditions:
+  """1.6.0: ``conditions=`` on get_incoming_edges()."""
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause(self, mock_db_client):
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_incoming_edges('user:alice', 'follows', client=mock_db_client)
+
+    sql = _emitted_sql(mock_db_client)
+    assert 'WHERE' not in sql
+    # The v3-safe form (record-anchored) is preserved.
+    assert 'user:alice<-follows' in sql
+
+  @pytest.mark.anyio
+  async def test_single_condition(self, mock_db_client):
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_incoming_edges(
+      'user:alice',
+      'follows',
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    assert "WHERE (tenant_id = 'acme')" in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_multiple_conditions_combine_with_and(self, mock_db_client):
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_incoming_edges(
+      'user:alice',
+      'follows',
+      conditions=[eq('tenant_id', 'acme'), eq('role', 'admin')],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert "tenant_id = 'acme'" in sql
+    assert "role = 'admin'" in sql
+    assert ' AND ' in sql
+
+
+class TestGetRelatedRecordsConditions:
+  """1.6.0: ``conditions=`` on get_related_records()."""
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause_typed(self, mock_db_client):
+    """Model code path stays clean by default."""
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_related_records(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      model=Post,
+      client=mock_db_client,
+    )
+
+    assert 'WHERE' not in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_default_no_where_clause_untyped(self, mock_db_client):
+    """No-model code path (returns raw dicts) also stays clean."""
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_related_records(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      client=mock_db_client,
+    )
+
+    assert 'WHERE' not in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_single_condition_typed(self, mock_db_client):
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_related_records(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      model=Post,
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    assert "WHERE (tenant_id = 'acme')" in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_single_condition_untyped(self, mock_db_client):
+    """Conditions also flow through the no-model code path."""
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_related_records(
+      'user:alice',
+      'likes',
+      'post',
+      direction='in',
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    assert "WHERE (tenant_id = 'acme')" in _emitted_sql(mock_db_client)
+
+  @pytest.mark.anyio
+  async def test_multiple_conditions_combine_with_and(self, mock_db_client):
+    from surql.types.operators import eq, gt
+
+    mock_db_client.execute = AsyncMock(return_value=[{'result': []}])
+
+    await get_related_records(
+      'user:alice',
+      'likes',
+      'post',
+      direction='out',
+      model=Post,
+      conditions=[eq('tenant_id', 'acme'), gt('score', 0)],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert "tenant_id = 'acme'" in sql
+    assert 'score > 0' in sql
+    assert ' AND ' in sql
+
+
+class TestShortestPathConditions:
+  """1.6.0: ``conditions=`` on shortest_path()."""
+
+  @pytest.mark.anyio
+  async def test_default_emits_only_id_predicate(self, mock_db_client):
+    """Default behaviour: only the mandatory ``id = <to>`` predicate."""
+    # Return non-empty on first iteration so the loop exits quickly.
+    mock_db_client.execute = AsyncMock(return_value=[{'id': 'user:bob'}])
+
+    await shortest_path(
+      'user:alice',
+      'user:bob',
+      'follows',
+      max_depth=2,
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert 'WHERE (id = user:bob)' in sql
+    assert ' AND ' not in sql
+
+  @pytest.mark.anyio
+  async def test_single_condition_appended(self, mock_db_client):
+    """User-supplied conditions widen the WHERE clause without dropping ``id =``."""
+    from surql.types.operators import eq
+
+    mock_db_client.execute = AsyncMock(return_value=[{'id': 'user:bob'}])
+
+    await shortest_path(
+      'user:alice',
+      'user:bob',
+      'follows',
+      max_depth=2,
+      conditions=[eq('tenant_id', 'acme')],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    # Both predicates must be present and AND-joined.
+    assert 'id = user:bob' in sql
+    assert "tenant_id = 'acme'" in sql
+    assert ' AND ' in sql
+
+  @pytest.mark.anyio
+  async def test_multiple_conditions_combine_with_and(self, mock_db_client):
+    from surql.types.operators import eq, gt
+
+    mock_db_client.execute = AsyncMock(return_value=[{'id': 'user:bob'}])
+
+    await shortest_path(
+      'user:alice',
+      'user:bob',
+      'follows',
+      max_depth=2,
+      conditions=[eq('tenant_id', 'acme'), gt('weight', 0)],
+      client=mock_db_client,
+    )
+
+    sql = _emitted_sql(mock_db_client)
+    assert 'id = user:bob' in sql
+    assert "tenant_id = 'acme'" in sql
+    assert 'weight > 0' in sql
+    # Three AND-joined predicates.
+    assert sql.count(' AND ') == 2

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.5.15"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Three coordinated changes that warrant a minor bump.

### Item 1 — Added: `conditions=` on graph helpers

Six graph traversal helpers — `traverse`, `traverse_with_depth`,
`get_related_records`, `get_outgoing_edges`, `get_incoming_edges`,
and `shortest_path` — now accept an optional
`conditions: list[str | Operator] | None` keyword. Each entry is
rendered through `Query.where(...)`, matching the exact shape that
`query_records` already accepts; multiple entries combine with AND.

Pre-1.6.0 these helpers emitted bare `SELECT ... FETCH ...` with no
WHERE hook, forcing any caller that needed row-level isolation
(multi-tenant filtering, archived exclusion) to roll a custom walker.
The parameter is purely additive — defaulting `None` leaves the
emitted SurrealQL byte-for-byte identical to 1.5.15. As part of the
refactor the four helpers that previously emitted hand-rolled f-string
SQL now route through the `Query` builder so WHERE composition matches
the rest of the query surface. 46 new regression tests.

### Item 2 — Fixed: transaction commits silently swallowed mid-batch failures

`Transaction.commit()` flushed buffered statements as a single
`BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` RPC via the SDK's
`query` method. SurrealDB v3 collapses that response to `None`
regardless of whether the batch succeeded OR was rolled back
server-side — verified against `surrealdb/surrealdb:v3.0.5` with
`surrealdb==2.0.0a1`. The commit helper read `None` as success, so a
single bad statement that triggered a rollback (type mismatch on a
SCHEMAFULL field, assertion failure, FK violation) was
indistinguishable from a clean commit. Callers saw "transaction
committed", went looking for their writes, and found nothing.

Fix: inject a sentinel `RETURN '__txn_ok__';` statement immediately
before the `COMMIT TRANSACTION` line, then route the commit RPC
through the SDK's `query_raw` method instead of `query`. `query_raw`
preserves the per-statement `{status, result}` envelope; the sentinel
surfaces as `{'result': '__txn_ok__', 'status': 'OK'}` on success and
is absent on rollback. `commit()` now inspects the envelope and
raises `TransactionError` with the server's per-statement explanation
when any statement has `status == 'ERR'` OR the sentinel is missing.
State transitions to `CANCELLED` (not `COMMITTED`) on this path.

Defensive fallback: when the underlying SDK does not expose
`query_raw` (older alpha versions, vendored forks), the commit falls
through to the prior `execute` path and logs a warning — silent
swallow is preserved only on SDK versions we cannot probe. 8 new
regression tests.

### Item 3 — Changed: typed-vs-untyped CRUD docs

Investigation revealed the typed (`*_typed`) and untyped (`*_record` /
`query_records`) surfaces are partial duplicates with deliberate
asymmetries, not full aliases:

- `create_typed` / `update_typed` / `upsert_typed` differ from their
  untyped siblings in return type only — untyped returns
  `dict[str, Any]`, typed revalidates the response into the model
  instance's class and returns `T`.
- `get_typed` is a thin alias of `get_record` (the untyped helper
  already returns `T | None` when given `model: type[T]`).
- `query_typed` is NOT a typed variant of `query_records`: the former
  runs hand-written SurrealQL, the latter uses the `Query` builder.

Module-level "when to use which" docstrings added to both
`crud.py` and `typed.py`, per-function docstrings now cross-reference
the alternative helper. No code change — both surfaces remain
supported.

## Verified

Sentinel-probe assumption was verified against live SurrealDB v3.0.5
before implementing the fix — confirmed that on success
`RETURN 'ok'` inside the batch DOES surface in the response when
routed via `query_raw`, and that on rollback the envelope carries
per-statement `status == 'ERR'` rows.

## Test plan

- [x] `uv run pytest --no-cov --ignore=tests/integration -q` — **2601 passed, 9 skipped, 2 xfailed** (was 2547 in 1.5.15; +54 new tests)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src --strict` — clean (81 source files)
- [x] End-to-end probe against live SurrealDB v3.0.5: success batch returns COMMITTED, mid-batch failure raises `TransactionError` with server error detail and transitions to CANCELLED