### PR TITLE
fix: 1.6.1 — Transaction.commit normalizes RecordID params (symmetry with DatabaseClient.execute)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-05-17
+
+### Fixed
+
+- **`Transaction.commit` skipped param normalisation, crashing on
+  `surql.RecordID` bound params.** `DatabaseClient.execute` routes its
+  incoming `params` dict through `_denormalize_params`, which converts
+  `surql.types.record_id.RecordID` (surql-py's Pydantic wrapper) to
+  `surrealdb.RecordID` (the SDK's native CBOR-encodable class) before
+  the encoder sees them. `Transaction.commit` flushed buffered
+  statements via `Transaction._raw_query` → `query_raw` (or the
+  fallback `DatabaseClient.execute`) and passed `self._params` through
+  unchanged — skipping the normalisation step entirely. The asymmetry
+  meant callers who placed `surql.RecordID` values into bound params
+  via `txn.execute(sql, {'foo': RecordID(...)})` crashed at commit
+  with `('no encoder for type ', <class 'surql.types.record_id.RecordID'>)`,
+  defeating the bound-param ergonomics inside transactions.
+
+  Fix: route the `Transaction` param dict through the existing
+  `_denormalize_params` helper inside `Transaction._raw_query` before
+  invoking `query_raw` or the fallback `execute`. No change to
+  `_denormalize_params` itself or to `DatabaseClient.execute`; the
+  only behavioural change is plumbing the existing normalisation into
+  the transaction path. The fallback `execute` branch double-normalises
+  (`execute` runs `_denormalize_params` again internally), which is a
+  no-op — `_denormalize_params` is idempotent on already-converted
+  `surrealdb.RecordID` values (they are neither a `SurqlRecordID`,
+  nor a regex-matching string, nor a dict/list, so they fall through
+  to the final `return value`). Module docstring on
+  `Transaction._raw_query` documents the symmetry with
+  `DatabaseClient.execute` and the idempotency rationale.
+
+  Regression coverage:
+  `tests/test_connection.py::TestTransaction::test_commit_normalizes_surql_record_id_params`
+  and `test_commit_normalizes_mixed_param_types` (4 new tests across
+  two anyio backends; mixed-type test guards against an over-eager
+  conversion damaging primitives, strings, lists, or nested dicts that
+  share a params dict with a `RecordID`).
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2605 passed**
+  (was 2601 in 1.6.0; +4 new regression tests covering the fix above).
+
 ## [1.6.0] - 2026-05-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.6.0"
+version = "1.6.1"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 __all__ = [
   # Configuration

--- a/src/surql/connection/transaction.py
+++ b/src/surql/connection/transaction.py
@@ -66,7 +66,7 @@ from typing import Any
 
 import structlog
 
-from surql.connection.client import DatabaseClient
+from surql.connection.client import DatabaseClient, _denormalize_params
 
 logger = structlog.get_logger(__name__)
 
@@ -256,6 +256,21 @@ class Transaction:
     silent-swallow behaviour on unsupported SDK versions rather than
     breaking the commit path.
 
+    Params are routed through :func:`_denormalize_params` before being
+    handed to the SDK so ``surql.types.record_id.RecordID`` values
+    (surql-py's Pydantic wrapper) are converted to ``surrealdb.RecordID``
+    (the SDK's native CBOR-encodable class) — symmetry with
+    :meth:`DatabaseClient.execute`, which already normalises its own
+    params. Without this conversion the SDK's CBOR encoder raises
+    ``no encoder for type <class 'surql.types.record_id.RecordID'>``
+    when callers queue bound-param RecordIDs via ``txn.execute``.
+    The fallback ``execute`` branch double-normalises (``execute``
+    runs ``_denormalize_params`` again internally) — that is a no-op
+    because ``_denormalize_params`` is idempotent: an already-converted
+    :class:`surrealdb.RecordID` is neither a ``SurqlRecordID``, nor a
+    string matching the record-id regex, nor a dict/list, so it falls
+    through to the final ``return value``.
+
     Args:
       batched: The full ``BEGIN ... <stmts> ... RETURN '<sentinel>'; COMMIT;``
         string.
@@ -270,12 +285,13 @@ class Transaction:
       callers must skip sentinel inspection in that case (the SDK has
       already collapsed the envelope and there is nothing to probe).
     """
+    resolved_params = _denormalize_params(params) if params else None
     sdk_client = getattr(self._client, '_client', None)
     query_raw = getattr(sdk_client, 'query_raw', None) if sdk_client is not None else None
     if query_raw is None:
       self._log.debug('query_raw_unavailable_falling_back_to_execute')
-      return await self._client.execute(batched, params), False
-    return await query_raw(batched, params or {}), True
+      return await self._client.execute(batched, resolved_params), False
+    return await query_raw(batched, resolved_params or {}), True
 
   async def cancel(self) -> None:
     """Cancel/rollback the transaction.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -884,6 +884,107 @@ class TestTransaction:
     assert txn.state == TransactionState.COMMITTED
 
   @pytest.mark.anyio
+  async def test_commit_normalizes_surql_record_id_params(
+    self, mock_db_client: DatabaseClient
+  ) -> None:
+    """1.6.1: Transaction.commit normalises ``surql.RecordID`` bound params.
+
+    ``DatabaseClient.execute`` runs incoming params through
+    ``_denormalize_params`` so ``surql.types.record_id.RecordID``
+    (surql-py's Pydantic wrapper) is converted to ``surrealdb.RecordID``
+    (the SDK's native CBOR-encodable class) before the SDK's encoder
+    sees them. Pre-1.6.1, ``Transaction.commit`` skipped that
+    normalisation and passed the params dict through unchanged to
+    ``query_raw``, so callers that queued ``surql.RecordID`` values via
+    bound params (``txn.execute(sql, {'parent': RecordID(...)})``)
+    crashed at commit with
+    ``no encoder for type <class 'surql.types.record_id.RecordID'>``.
+
+    The fix routes the Transaction param dict through the same
+    ``_denormalize_params`` helper inside ``Transaction._raw_query``.
+    This asserts the params handed to the SDK are
+    ``surrealdb.RecordID`` instances, NOT surql-py's wrapper.
+    """
+    from surrealdb import RecordID as SdkRecordID
+
+    from surql.types.record_id import RecordID as SurqlRecordID
+
+    captured: dict[str, dict[str, object]] = {}
+
+    async def capture_query_raw(_sql: str, params: dict[str, object]) -> dict[str, object]:
+      captured['params'] = params
+      return {'result': [{'result': '__txn_ok__', 'status': 'OK'}]}
+
+    mock_db_client._client.query_raw = AsyncMock(side_effect=capture_query_raw)
+
+    txn = Transaction(mock_db_client)
+    await txn.begin()
+    await txn.execute(
+      'UPDATE foo:bar SET parent = $parent',
+      {'parent': SurqlRecordID(table='foo', id='baz')},
+    )
+    # The commit must not raise: pre-1.6.1 the SDK's CBOR encoder
+    # would reject the surql-py wrapper.
+    await txn.commit()
+
+    assert txn.state == TransactionState.COMMITTED
+    sdk_params = captured['params']
+    assert 'parent' in sdk_params
+    # Critical: the SDK must receive the native ``surrealdb.RecordID``,
+    # not surql-py's Pydantic wrapper. If this assertion regresses, the
+    # ``no encoder`` crash will return for real callers.
+    assert isinstance(sdk_params['parent'], SdkRecordID)
+    assert not isinstance(sdk_params['parent'], SurqlRecordID)
+    assert sdk_params['parent'].table_name == 'foo'
+    assert sdk_params['parent'].id == 'baz'
+
+  @pytest.mark.anyio
+  async def test_commit_normalizes_mixed_param_types(self, mock_db_client: DatabaseClient) -> None:
+    """1.6.1: param normalisation preserves non-RecordID values.
+
+    ``_denormalize_params`` recurses into dicts/lists; primitives and
+    other values pass through untouched. This guards against a future
+    over-eager conversion damaging strings, ints, bools, dicts, or
+    lists that share a params dict with a ``surql.RecordID``.
+    """
+    from surrealdb import RecordID as SdkRecordID
+
+    from surql.types.record_id import RecordID as SurqlRecordID
+
+    captured: dict[str, dict[str, object]] = {}
+
+    async def capture_query_raw(_sql: str, params: dict[str, object]) -> dict[str, object]:
+      captured['params'] = params
+      return {'result': [{'result': '__txn_ok__', 'status': 'OK'}]}
+
+    mock_db_client._client.query_raw = AsyncMock(side_effect=capture_query_raw)
+
+    txn = Transaction(mock_db_client)
+    await txn.begin()
+    await txn.execute(
+      'UPDATE foo:bar SET parent = $parent, name = $name, count = $count, '
+      'tags = $tags, meta = $meta',
+      {
+        'parent': SurqlRecordID(table='foo', id='baz'),
+        'name': 'Alice',
+        'count': 42,
+        'tags': ['a', 'b', 'c'],
+        'meta': {'active': True, 'score': 3.14},
+      },
+    )
+    await txn.commit()
+
+    assert txn.state == TransactionState.COMMITTED
+    sdk_params = captured['params']
+    # RecordID converted to SDK type.
+    assert isinstance(sdk_params['parent'], SdkRecordID)
+    # Primitives untouched.
+    assert sdk_params['name'] == 'Alice'
+    assert sdk_params['count'] == 42
+    assert sdk_params['tags'] == ['a', 'b', 'c']
+    assert sdk_params['meta'] == {'active': True, 'score': 3.14}
+
+  @pytest.mark.anyio
   async def test_duplicate_param_keys_rejected(self, mock_db_client: DatabaseClient) -> None:
     """Duplicate param names across queued statements raise early."""
     txn = Transaction(mock_db_client)

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

`DatabaseClient.execute` routes incoming params through `_denormalize_params`, which converts `surql.types.record_id.RecordID` (surql-py's Pydantic wrapper) to `surrealdb.RecordID` (the SDK's native CBOR-encodable class) before the encoder sees them. `Transaction.commit` flushed buffered statements via `Transaction._raw_query` (which calls `query_raw` or the fallback `execute`) and passed `self._params` through unchanged, skipping that normalization. The asymmetry meant callers placing `surql.RecordID` values into bound params via `txn.execute(sql, {'foo': RecordID(...)})` crashed at commit with:

```
('no encoder for type ', <class 'surql.types.record_id.RecordID'>)
```

Verified 2026-05-17 against 1.6.0 from a downstream consumer's seed-loader refactor. The workaround (emit each statement via `Query().upsert(target, payload).to_surql()`, which inlines RecordIDs as record-link literals with no bound params) defeats the bound-param ergonomics inside transactions.

## Fix

Route the `Transaction` param dict through the existing `_denormalize_params` helper inside `Transaction._raw_query` before invoking `query_raw` or the fallback `execute`. No change to `_denormalize_params` itself or to `DatabaseClient.execute` — the only behavioural change is plumbing the existing normalization into the transaction path.

The fallback `execute` branch double-normalizes (`DatabaseClient.execute` runs `_denormalize_params` again internally); that is a no-op because `_denormalize_params` is idempotent on already-converted `surrealdb.RecordID` values (they are neither a `SurqlRecordID`, nor a regex-matching string, nor a dict/list, so they fall through to the final `return value`). The updated `_raw_query` docstring documents both the symmetry rationale and the idempotency observation.

## Test plan

- [x] `test_commit_normalizes_surql_record_id_params` — queues a statement that passes a `surql.RecordID` via bound params, commits, asserts the params handed to `query_raw` carry a `surrealdb.RecordID` (NOT surql-py's wrapper).
- [x] `test_commit_normalizes_mixed_param_types` — RecordID alongside primitive types (string, int, list, nested dict), to confirm the normalization doesn't damage other values.
- [x] `uv run pytest --no-cov --ignore=tests/integration` — **2605 passed**, 9 skipped, 2 xfailed (was 2601 at 1.6.0; +4 new tests across two anyio backends).
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] `uv run mypy src --strict` — no issues, 81 source files.