### PR TITLE
fix: 1.6.3 — diff_tables symmetry (typed-record VALUE, v3 define_table, comma-joined PERMISSIONS)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-05-18
+
+### Fixed
+
+- **`diff_tables` still reported false-positive drift on typed record-link
+  fields whose code-side declaration carried the canonical
+  `type::record("<target>", $value)` coercion alongside `target_table=`.**
+  The 1.5.14 emitter (`schema/sql.py::_record_type_clause`) already drops
+  this redundant VALUE on write — once `target_table` is set the typed
+  `record<X>` declaration constrains the column on its own — but the
+  in-memory `FieldDefinition` returned by the `field()` constructor still
+  held the coercion string. A live DB introspected after `migrate_up`
+  therefore reported `value=None` while the code-side definition reported
+  `value="type::record(...)"`, and every diff produced a spurious
+  `MODIFY_FIELD` entry. Fix: in `surql.schema.fields.field()`, once
+  `target_table` is set (whether passed explicitly or auto-detected from
+  the coercion pattern) and the supplied `value=` round-trips through
+  `_detect_target_table_from_value` to the same target, clear `value` to
+  `None` before constructing the `FieldDefinition`. The mismatch case
+  (`target_table='X'` plus `value='type::record("Y", $value)'`) is left
+  untouched — silently dropping a value that targets a different table
+  would be a footgun.
+
+- **`parse_table_info` silently lost table-level mode + PERMISSIONS on
+  SurrealDB v3.** Pre-1.6.3 the parser read `info.get('tb', '')` as the
+  source of the `DEFINE TABLE` statement string, which is correct for the
+  v2 `INFO FOR TABLE` shape but **does not exist** in v3 — v3 returns
+  `{events, fields, indexes, lives, tables}` and surfaces the
+  `DEFINE TABLE` string only via `INFO FOR DB`'s `tables.<name>` dict.
+  The result: on v3, the parsed `TableDefinition` always had
+  `permissions=None` and `mode=SCHEMALESS`, and every consumer that
+  declared table-level PERMISSIONS saw a false-positive
+  `MODIFY_PERMISSIONS` diff on every call. Fix: `parse_table_info` accepts
+  a new optional `define_table: str | None = None` parameter that, when
+  passed, is used as the source of `tb_definition` for mode + PERMISSIONS
+  parsing. Callers fetch `INFO FOR DB` once and pass
+  `db_info['tables'][<name>]` alongside the per-table info dict. Behaviour
+  is fully backwards-compatible: when `define_table` is `None`, the parser
+  falls back to the legacy `info.get('tb', '')` and the v2 shape continues
+  to round-trip unchanged.
+
+- **`_parse_table_permissions` failed to match the comma-joined action-list
+  shape SurrealDB v3 emits when multiple actions share a single rule.**
+  v3's serialiser collapses
+  `PERMISSIONS FOR select WHERE r FOR create WHERE r FOR update WHERE r FOR delete WHERE r`
+  down to the compact
+  `PERMISSIONS FOR select, create, update, delete WHERE r` form. The
+  pre-1.6.3 regex
+  `\bFOR\s+(select|create|update|delete)\s+WHERE\s+...` only captured a
+  single bare action keyword, so the comma-list form matched nothing and
+  the parser returned `None` — feeding straight into the same false-positive
+  `MODIFY_PERMISSIONS` diff on every consumer with collapsed per-action
+  rules. Fix: the regex now captures
+  `((?:action)(?:\s*,\s*(?:action))*)` as a list, the parser splits on
+  commas, and each per-action key in the returned dict gets the same rule
+  string. Both the expanded form (one rule per `FOR ... WHERE` clause) and
+  the comma-joined form (one rule shared across an action list) parse
+  into the same `dict[str, str]` shape that
+  `table_schema(permissions=...)` accepts. Mixed forms — some actions
+  grouped via comma, others split into separate clauses — also work
+  because each `FOR <list> WHERE <rule>` clause is parsed independently
+  and exploded.
+
+  Regression coverage: 4 new tests in `tests/test_diff_round_trip.py`:
+  `test_record_field_with_target_table_drops_canonical_value`,
+  `test_parse_table_info_uses_define_table_for_permissions`,
+  `test_parse_table_permissions_handles_comma_joined_actions`, and an
+  end-to-end `test_round_trip_typed_record_field_with_table_permissions_is_empty`
+  that builds a code-side `TableDefinition` with both a typed-record field
+  and table-level PERMISSIONS, serialises via `generate_table_sql`, and
+  feeds the result back through `parse_table_info(define_table=...)`
+  asserting `diff_tables(live, code) == []`. Each test fails on 1.6.2 and
+  passes on 1.6.3.
+
+### Verified
+
+- `ruff check src tests` + `ruff format --check src tests` — clean.
+- `mypy src --strict` — no issues.
+- `uv run pytest --no-cov --ignore=tests/integration` — **2620 passed,
+  9 skipped, 2 xfailed** (was 2616 in 1.6.2; +4 new regression tests
+  covering the fixes above).
+
 ## [1.6.2] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.6.2"
+version = "1.6.3"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.6.2'
+__version__ = '1.6.3'
 
 __all__ = [
   # Configuration

--- a/src/surql/schema/fields.py
+++ b/src/surql/schema/fields.py
@@ -167,6 +167,21 @@ def field(
   if field_type == FieldType.RECORD and target_table is None:
     target_table = _detect_target_table_from_value(value)
 
+  # Once `target_table` is set on a RECORD field, the canonical
+  # `type::record("<target_table>", $value)` coercion is redundant — the typed
+  # `record<X>` already constrains the column. The emitter drops it on write
+  # (see schema/sql.py::_record_type_clause), so drop it from the in-memory
+  # FieldDefinition too. Otherwise consumers built against a live DB (which
+  # never stores the VALUE) see a phantom mismatch in `diff_tables` between
+  # code-side `value="type::record(...)"` and live-side `value=None`.
+  if (
+    field_type == FieldType.RECORD
+    and target_table is not None
+    and value is not None
+    and _detect_target_table_from_value(value) == target_table
+  ):
+    value = None
+
   return FieldDefinition(
     name=name,
     type=field_type,

--- a/src/surql/schema/parser.py
+++ b/src/surql/schema/parser.py
@@ -84,12 +84,20 @@ _ARRAY_SUBFIELD_PATTERN = re.compile(r'(?:\[\*\]|\.\*)\s*$')
 def parse_table_info(
   table_name: str,
   info: dict[str, Any],
+  define_table: str | None = None,
 ) -> TableDefinition:
   """Parse SurrealDB INFO FOR TABLE response into TableDefinition.
 
   Args:
     table_name: Name of the table
     info: Raw INFO FOR TABLE response dictionary
+    define_table: Optional ``DEFINE TABLE <name> ...`` statement string. When
+      provided, used as the source of table-level mode + PERMISSIONS. Pass this
+      when introspecting against SurrealDB v3, which does NOT include the
+      table-level DEFINE statement in ``INFO FOR TABLE`` (only ``INFO FOR DB``'s
+      ``tables.<name>`` dict carries it). Without this, table-level PERMISSIONS
+      are silently lost on round-trip and every consumer that declares them
+      sees a false-positive ``MODIFY_PERMISSIONS`` diff.
 
   Returns:
     Parsed TableDefinition
@@ -98,13 +106,26 @@ def parse_table_info(
     SchemaParseError: If parsing fails
 
   Examples:
+    >>> # SurrealDB v2 — tb is inside INFO FOR TABLE
     >>> info = await client.execute(f'INFO FOR TABLE {table_name};')
     >>> table_def = parse_table_info(table_name, info[0]['result'])
+
+    >>> # SurrealDB v3 — fetch the DEFINE TABLE string from INFO FOR DB and
+    >>> # pass it alongside the per-table info dict.
+    >>> db_info = await client.execute('INFO FOR DB;')
+    >>> info = await client.execute(f'INFO FOR TABLE {table_name};')
+    >>> table_def = parse_table_info(
+    ...     table_name,
+    ...     info[0]['result'],
+    ...     define_table=db_info[0]['result']['tables'].get(table_name),
+    ... )
   """
   try:
     logger.debug('parsing_table_info', table=table_name)
 
-    tb_definition = info.get('tb', '')
+    # Caller-supplied DEFINE TABLE statement wins; fall back to the
+    # legacy `tb` key inside the INFO FOR TABLE response (SurrealDB v2 shape).
+    tb_definition = define_table if define_table is not None else info.get('tb', '')
 
     # Parse table mode from tb field
     mode = _parse_table_mode(tb_definition)
@@ -179,9 +200,15 @@ def _parse_table_permissions(tb_definition: str) -> dict[str, str] | None:
     helper has no representation for "all actions = full"; this normalisation
     avoids a permanent false-positive `MODIFY_PERMISSIONS` diff on every table
     whose code declaration omitted permissions).
-  - ``PERMISSIONS FOR select WHERE <r1> FOR create WHERE <r2> ...`` →
-    returns ``{'select': '<r1>', 'create': '<r2>', ...}`` matching the
-    code-side `dict[str, str]` shape.
+  - ``PERMISSIONS FOR select WHERE <r1> FOR create WHERE <r2> ...`` (expanded
+    form) → returns ``{'select': '<r1>', 'create': '<r2>', ...}``.
+  - ``PERMISSIONS FOR select, create, update, delete WHERE <rule>`` (compact
+    comma-joined form — what SurrealDB v3's emitter actually produces when
+    multiple actions share a single rule) → returns
+    ``{'select': '<rule>', 'create': '<rule>', 'update': '<rule>', 'delete': '<rule>'}``.
+  - Mixed forms (some actions grouped via comma, others split) are handled
+    by parsing each ``FOR <action-list> WHERE <rule>`` clause independently
+    and exploding the action list into per-action entries.
 
   Returns ``None`` when no PERMISSIONS clause is present.
   """
@@ -207,17 +234,19 @@ def _parse_table_permissions(tb_definition: str) -> dict[str, str] | None:
   if body.upper() in ('NONE', 'FULL'):
     return None
 
-  # Per-action form: collect all `FOR <action> WHERE <rule>` clauses.
-  # Capture each rule up to the next `FOR`, end-of-string, or semicolon.
+  # Per-action form: each clause is `FOR <action-list> WHERE <rule>` where
+  # `<action-list>` is one or more comma-separated `select|create|update|delete`
+  # keywords. Capture both list-of-actions and rule, then explode.
   rules: dict[str, str] = {}
   for action_match in re.finditer(
-    r'\bFOR\s+(select|create|update|delete)\s+WHERE\s+(.*?)(?=\s+FOR\s+(?:select|create|update|delete)\b|\s*;|\s*$)',
+    r'\bFOR\s+((?:select|create|update|delete)(?:\s*,\s*(?:select|create|update|delete))*)\s+WHERE\s+(.*?)(?=\s+FOR\s+(?:select|create|update|delete)\b|\s*;|\s*$)',
     body,
     re.IGNORECASE | re.DOTALL,
   ):
-    action = action_match.group(1).lower()
+    actions_raw = action_match.group(1)
     rule = action_match.group(2).strip()
-    rules[action] = rule
+    for action in re.split(r'\s*,\s*', actions_raw):
+      rules[action.lower()] = rule
 
   return rules or None
 

--- a/tests/test_diff_round_trip.py
+++ b/tests/test_diff_round_trip.py
@@ -32,7 +32,8 @@ from surql.schema.fields import (
   field,
   object_field,
 )
-from surql.schema.parser import parse_table_info
+from surql.schema.parser import _parse_table_permissions, parse_table_info
+from surql.schema.sql import generate_table_sql
 from surql.schema.table import table_schema
 
 
@@ -349,6 +350,148 @@ def test_diff_real_consumer_shape_round_trip_is_empty() -> None:
   diffs = diff_tables(live_table, code_table)
   assert diffs == [], (
     f'expected zero drift for end-to-end shape; got: {[d.description for d in diffs]}'
+  )
+
+
+# ---------- 1.6.3 regression tests ----------
+
+
+def test_record_field_with_target_table_drops_canonical_value() -> None:
+  """1.6.3 Fix A: when a RECORD field has both `target_table` set AND a `value=`
+  that matches the canonical `type::record("<target_table>", $value)` coercion,
+  the `field()` constructor must clear `value` on the resulting
+  `FieldDefinition`.
+
+  The emitter (`schema/sql.py::_record_type_clause`) already drops the VALUE on
+  write when `target_table` is set; pre-1.6.3 the in-memory `FieldDefinition`
+  still carried the redundant coercion, so `diff_tables` saw a false-positive
+  `MODIFY_FIELD` between code-side `value="type::record(...)"` and live-side
+  `value=None`.
+  """
+  fd = field(
+    'spec',
+    FieldType.RECORD,
+    target_table='other',
+    value='type::record("other", $value)',
+  )
+  assert fd.target_table == 'other'
+  assert fd.value is None, (
+    f'expected canonical type::record coercion to be cleared when target_table is set; '
+    f'got value={fd.value!r}'
+  )
+
+  # Sanity: when the coercion targets a DIFFERENT table than `target_table`, do
+  # NOT silently drop it — that would be a behavioural footgun. The auto-clear
+  # only fires when the two are consistent.
+  fd_mismatch = field(
+    'spec',
+    FieldType.RECORD,
+    target_table='other',
+    value='type::record("different", $value)',
+  )
+  assert fd_mismatch.value == 'type::record("different", $value)'
+
+
+def test_parse_table_info_uses_define_table_for_permissions() -> None:
+  """1.6.3 Fix B: when the caller passes `define_table=...`, `parse_table_info`
+  must source table-level mode + PERMISSIONS from that string rather than
+  `info['tb']`.
+
+  SurrealDB v3's `INFO FOR TABLE` returns `{events, fields, indexes, lives,
+  tables}` — there is no `tb` key. Without the `define_table` parameter
+  introduced in 1.6.3, table-level PERMISSIONS were silently dropped on every
+  v3 round-trip, producing a false-positive `MODIFY_PERMISSIONS` diff on every
+  consumer that declared them.
+  """
+  # Synthetic v3-shaped INFO FOR TABLE: deliberately omits `tb`.
+  info: dict[str, object] = {
+    'events': {},
+    'fields': {
+      'name': 'DEFINE FIELD name ON community TYPE string PERMISSIONS FULL',
+    },
+    'indexes': {},
+    'lives': {},
+    'tables': {},
+  }
+  define_table = (
+    'DEFINE TABLE community SCHEMAFULL '
+    'PERMISSIONS FOR select WHERE true FOR create WHERE $auth.id != NONE'
+  )
+
+  table = parse_table_info('community', info, define_table=define_table)
+
+  assert table.permissions == {
+    'select': 'true',
+    'create': '$auth.id != NONE',
+  }, f'expected per-action permissions parsed from define_table; got: {table.permissions!r}'
+
+
+def test_parse_table_permissions_handles_comma_joined_actions() -> None:
+  """1.6.3 Fix C: `_parse_table_permissions` must recognise the comma-joined
+  `FOR <action-list> WHERE <rule>` shape SurrealDB v3 emits when multiple
+  actions share a single rule, and explode it into per-action entries with
+  the same rule string on every key.
+
+  Pre-1.6.3 the regex `\\bFOR\\s+(select|create|update|delete)\\s+WHERE\\s+...`
+  would not match the comma form at all, so every consumer with collapsed
+  per-action permissions saw a false-positive `MODIFY_PERMISSIONS` diff.
+  """
+  define_table = (
+    'DEFINE TABLE foo SCHEMAFULL '
+    'PERMISSIONS FOR select, create, update, delete WHERE tenant_id = $auth.tenant'
+  )
+  rules = _parse_table_permissions(define_table)
+  assert rules == {
+    'select': 'tenant_id = $auth.tenant',
+    'create': 'tenant_id = $auth.tenant',
+    'update': 'tenant_id = $auth.tenant',
+    'delete': 'tenant_id = $auth.tenant',
+  }, f'expected comma-joined action list exploded into four equal entries; got: {rules!r}'
+
+
+def test_round_trip_typed_record_field_with_table_permissions_is_empty() -> None:
+  """1.6.3 end-to-end: build a code-side `TableDefinition` with one typed-record
+  field AND table-level PERMISSIONS, emit it via `generate_table_sql`, feed
+  the DEFINE TABLE + DEFINE FIELD strings back through `parse_table_info`
+  (passing the DEFINE TABLE as `define_table` to simulate the v3 shape), and
+  assert `diff_tables(live, code) == []`.
+
+  This exercises Fix A (the typed-record code-side value is never emitted),
+  Fix B (`define_table` carries the table-level permissions), and Fix C
+  indirectly (the per-action emitter form is what we round-trip here).
+  """
+  code_table = table_schema(
+    'community',
+    fields=[
+      field('spec', FieldType.RECORD, target_table='data_capture_spec', nullable=True),
+    ],
+    permissions={'select': 'true', 'create': '$auth.id != NONE'},
+  )
+
+  statements = generate_table_sql(code_table)
+  # Index 0 is the DEFINE TABLE; subsequent entries are DEFINE FIELDs.
+  define_table_stmt = statements[0].rstrip(';')
+  fields_dict = {}
+  for stmt in statements[1:]:
+    body = stmt.rstrip(';')
+    # `DEFINE FIELD <name> ON [TABLE] <table> ...` — extract <name>.
+    parts = body.split()
+    # parts[0]='DEFINE', parts[1]='FIELD', parts[2]=<name>
+    field_name = parts[2]
+    fields_dict[field_name] = body
+
+  live_info: dict[str, object] = {
+    'events': {},
+    'fields': fields_dict,
+    'indexes': {},
+    'lives': {},
+    'tables': {},
+  }
+  live_table = parse_table_info('community', live_info, define_table=define_table_stmt)
+  diffs = diff_tables(live_table, code_table)
+  assert diffs == [], (
+    f'expected zero drift for typed-record + table-permissions round-trip; '
+    f'got: {[d.description for d in diffs]}'
   )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
### Fixed

- **`diff_tables` still reported false-positive drift on typed record-link
  fields whose code-side declaration carried the canonical
  `type::record("<target>", $value)` coercion alongside `target_table=`.**
  The 1.5.14 emitter (`schema/sql.py::_record_type_clause`) already drops
  this redundant VALUE on write — once `target_table` is set the typed
  `record<X>` declaration constrains the column on its own — but the
  in-memory `FieldDefinition` returned by the `field()` constructor still
  held the coercion string. A live DB introspected after `migrate_up`
  therefore reported `value=None` while the code-side definition reported
  `value="type::record(...)"`, and every diff produced a spurious
  `MODIFY_FIELD` entry. Fix: in `surql.schema.fields.field()`, once
  `target_table` is set (whether passed explicitly or auto-detected from
  the coercion pattern) and the supplied `value=` round-trips through
  `_detect_target_table_from_value` to the same target, clear `value` to
  `None` before constructing the `FieldDefinition`. The mismatch case
  (`target_table='X'` plus `value='type::record("Y", $value)'`) is left
  untouched — silently dropping a value that targets a different table
  would be a footgun.

- **`parse_table_info` silently lost table-level mode + PERMISSIONS on
  SurrealDB v3.** Pre-1.6.3 the parser read `info.get('tb', '')` as the
  source of the `DEFINE TABLE` statement string, which is correct for the
  v2 `INFO FOR TABLE` shape but **does not exist** in v3 — v3 returns
  `{events, fields, indexes, lives, tables}` and surfaces the
  `DEFINE TABLE` string only via `INFO FOR DB`'s `tables.<name>` dict.
  The result: on v3, the parsed `TableDefinition` always had
  `permissions=None` and `mode=SCHEMALESS`, and every consumer that
  declared table-level PERMISSIONS saw a false-positive
  `MODIFY_PERMISSIONS` diff on every call. Fix: `parse_table_info` accepts
  a new optional `define_table: str | None = None` parameter that, when
  passed, is used as the source of `tb_definition` for mode + PERMISSIONS
  parsing. Callers fetch `INFO FOR DB` once and pass
  `db_info['tables'][<name>]` alongside the per-table info dict. Behaviour
  is fully backwards-compatible: when `define_table` is `None`, the parser
  falls back to the legacy `info.get('tb', '')` and the v2 shape continues
  to round-trip unchanged.

- **`_parse_table_permissions` failed to match the comma-joined action-list
  shape SurrealDB v3 emits when multiple actions share a single rule.**
  v3's serialiser collapses
  `PERMISSIONS FOR select WHERE r FOR create WHERE r FOR update WHERE r FOR delete WHERE r`
  down to the compact
  `PERMISSIONS FOR select, create, update, delete WHERE r` form. The
  pre-1.6.3 regex
  `\bFOR\s+(select|create|update|delete)\s+WHERE\s+...` only captured a
  single bare action keyword, so the comma-list form matched nothing and
  the parser returned `None` — feeding straight into the same false-positive
  `MODIFY_PERMISSIONS` diff on every consumer with collapsed per-action
  rules. Fix: the regex now captures
  `((?:action)(?:\s*,\s*(?:action))*)` as a list, the parser splits on
  commas, and each per-action key in the returned dict gets the same rule
  string. Both the expanded form (one rule per `FOR ... WHERE` clause) and
  the comma-joined form (one rule shared across an action list) parse
  into the same `dict[str, str]` shape that
  `table_schema(permissions=...)` accepts. Mixed forms — some actions
  grouped via comma, others split into separate clauses — also work
  because each `FOR <list> WHERE <rule>` clause is parsed independently
  and exploded.

  Regression coverage: 4 new tests in `tests/test_diff_round_trip.py`:
  `test_record_field_with_target_table_drops_canonical_value`,
  `test_parse_table_info_uses_define_table_for_permissions`,
  `test_parse_table_permissions_handles_comma_joined_actions`, and an
  end-to-end `test_round_trip_typed_record_field_with_table_permissions_is_empty`
  that builds a code-side `TableDefinition` with both a typed-record field
  and table-level PERMISSIONS, serialises via `generate_table_sql`, and
  feeds the result back through `parse_table_info(define_table=...)`
  asserting `diff_tables(live, code) == []`. Each test fails on 1.6.2 and
  passes on 1.6.3.

### Verified

- `ruff check src tests` + `ruff format --check src tests` — clean.
- `mypy src --strict` — no issues.
- `uv run pytest --no-cov --ignore=tests/integration` — **2620 passed,
  9 skipped, 2 xfailed** (was 2616 in 1.6.2; +4 new regression tests
  covering the fixes above).