### PR TITLE
feat: 1.6.4 — add parse_edge_info for drift-detecting graph edges

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-05-18
+
+### Added
+
+- **`parse_edge_info(edge_name, info, define_table=None)` in
+  `surql.schema.parser`.** Counterpart to `parse_table_info` for graph-edge
+  tables defined via `edge_schema` / `EdgeDefinition`. Round-trips the three
+  edge modes (`RELATION`, `SCHEMAFULL`, `SCHEMALESS`), the
+  `FROM <table> TO <table>` clauses on `TYPE RELATION` edges, and the
+  per-action `PERMISSIONS` clause SurrealDB v3 emits on the table-level
+  `DEFINE TABLE` statement. Reuses the existing `_parse_fields`,
+  `_parse_indexes`, `_parse_events`, and `_parse_table_permissions` helpers
+  so every per-field shape the table parser handles (typed record links,
+  `option<X>`, FLEXIBLE, sub-fields, fields named `default`) round-trips
+  the same way on edges. For `RELATION`-mode edges the auto-emitted `in`
+  and `out` fields are stripped on parse so they do not show up as orphan
+  diffs against a code-side `EdgeDefinition` that (correctly) does not
+  declare them. Exported from `surql.schema` alongside `parse_table_info`.
+
+  Before 1.6.4, drift detectors could check edges' presence/absence by
+  cross-referencing `ALL_EDGES.keys()` against `INFO FOR DB.tables` but had
+  no way to diff edge MODE, FROM/TO endpoints, or per-edge fields/indexes
+  against the live DB — `parse_table_info` returned a `TableDefinition`
+  with `mode=SCHEMALESS` and no edge metadata. With `parse_edge_info` plus
+  the existing `diff_edges`, edge round-trip parity is now on the same
+  footing as table parity.
+
+### Changed
+
+- `surql.schema.__init__` re-exports `parse_edge_info` so downstream
+  packages can `from surql.schema import parse_edge_info` next to the
+  existing `parse_table_info` / `parse_db_info`.
+
 ## [1.6.3] - 2026-05-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oneiriq-surql"
 
-version = "1.6.3"
+version = "1.6.4"
 description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD."
 authors = [
   { name = "Shon Thomas", email = "shon@oneiriq.com" }

--- a/src/surql/__init__.py
+++ b/src/surql/__init__.py
@@ -106,7 +106,7 @@ from surql.types import (
   type_thing,
 )
 
-__version__ = '1.6.3'
+__version__ = '1.6.4'
 
 __all__ = [
   # Configuration

--- a/src/surql/schema/__init__.py
+++ b/src/surql/schema/__init__.py
@@ -43,6 +43,7 @@ from surql.schema.fields import (
 from surql.schema.parser import (
   SchemaParseError,
   parse_db_info,
+  parse_edge_info,
   parse_table_info,
 )
 from surql.schema.registry import (
@@ -154,6 +155,7 @@ __all__ = [
   # Parser
   'SchemaParseError',
   'parse_table_info',
+  'parse_edge_info',
   'parse_db_info',
   # Themes
   'ColorScheme',

--- a/src/surql/schema/parser.py
+++ b/src/surql/schema/parser.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import structlog
 
+from surql.schema.edge import EdgeDefinition, EdgeMode
 from surql.schema.fields import FieldDefinition, FieldType
 from surql.schema.table import (
   EventDefinition,
@@ -162,6 +163,135 @@ def parse_table_info(
   except Exception as e:
     logger.error('parse_table_info_failed', table=table_name, error=str(e))
     raise SchemaParseError(f'Failed to parse table {table_name}: {e}') from e
+
+
+def parse_edge_info(
+  edge_name: str,
+  info: dict[str, Any],
+  define_table: str | None = None,
+) -> EdgeDefinition:
+  """Parse an edge table's ``INFO FOR TABLE`` response into an EdgeDefinition.
+
+  Counterpart to :func:`parse_table_info` for graph-edge tables defined via
+  ``edge_schema`` / :class:`~surql.schema.edge.EdgeDefinition`. Edges round-trip
+  through SurrealDB as regular tables in ``INFO FOR DB.tables``; the only thing
+  that makes them edges is the ``TYPE RELATION FROM <x> TO <y>`` clause on the
+  ``DEFINE TABLE`` statement. Without an edge-aware parser, a drift detector
+  using :func:`parse_table_info` against an edge table would see it as a
+  SCHEMALESS table missing every field-level diff signal an edge expects (mode,
+  from/to constraints, auto ``in``/``out`` proxies).
+
+  Args:
+    edge_name: Edge table name.
+    info: Raw ``INFO FOR TABLE`` response dictionary (same shape as the
+      ``parse_table_info`` input — typically the inner result dict).
+    define_table: Optional ``DEFINE TABLE <name> ...`` statement string. When
+      provided, the source of edge mode + FROM/TO + PERMISSIONS. Pass this on
+      SurrealDB v3, where ``INFO FOR TABLE`` does not include the table-level
+      DEFINE — only ``INFO FOR DB``'s ``tables.<name>`` dict does.
+
+  Returns:
+    Parsed EdgeDefinition with mode, from_table, to_table, fields, indexes,
+    events, and permissions populated. For ``RELATION``-mode edges the auto
+    ``in`` and ``out`` fields SurrealDB emits are skipped (they are implicit
+    when ``TYPE RELATION`` is set, so the code-side EdgeDefinition does not
+    declare them either).
+
+  Raises:
+    SchemaParseError: If parsing fails.
+
+  Examples:
+    >>> db_info = await client.execute('INFO FOR DB;')
+    >>> info = await client.execute(f'INFO FOR TABLE {edge_name};')
+    >>> edge_def = parse_edge_info(
+    ...     edge_name,
+    ...     info[0]['result'],
+    ...     define_table=db_info[0]['result']['tables'].get(edge_name),
+    ... )
+  """
+  try:
+    logger.debug('parsing_edge_info', edge=edge_name)
+
+    tb_definition = define_table if define_table is not None else info.get('tb', '')
+
+    mode = _parse_edge_mode(tb_definition)
+    from_table, to_table = _parse_edge_from_to(tb_definition)
+    permissions = _parse_table_permissions(tb_definition)
+
+    fields_dict = info.get('fields') or info.get('fd') or {}
+    fields = _parse_fields(fields_dict)
+    # `in` and `out` are auto-emitted by SurrealDB for TYPE RELATION edges and
+    # are not part of the code-side EdgeDefinition's `fields` list. Strip them
+    # so round-trip diffs do not flag them as orphan additions.
+    if mode == EdgeMode.RELATION:
+      fields = [f for f in fields if f.name not in ('in', 'out')]
+
+    indexes_dict = info.get('indexes') or info.get('ix') or {}
+    indexes = _parse_indexes(indexes_dict)
+
+    events_dict = info.get('events') or info.get('ev') or {}
+    events = _parse_events(events_dict)
+
+    return EdgeDefinition(
+      name=edge_name,
+      mode=mode,
+      from_table=from_table,
+      to_table=to_table,
+      fields=fields,
+      indexes=indexes,
+      events=events,
+      permissions=permissions,
+    )
+
+  except Exception as e:
+    logger.error('parse_edge_info_failed', edge=edge_name, error=str(e))
+    raise SchemaParseError(f'Failed to parse edge {edge_name}: {e}') from e
+
+
+# Pattern matching `TYPE RELATION` (case-insensitive, word-boundary anchored).
+_TYPE_RELATION_PATTERN = re.compile(r'\bTYPE\s+RELATION\b', re.IGNORECASE)
+
+# Pattern matching `FROM <ident>` and `TO <ident>` in a DEFINE TABLE statement.
+# Identifier characters mirror SurrealDB's table-name grammar (letter/digit/_).
+_EDGE_FROM_PATTERN = re.compile(r'\bFROM\s+([A-Za-z_][A-Za-z0-9_]*)', re.IGNORECASE)
+_EDGE_TO_PATTERN = re.compile(r'\bTO\s+([A-Za-z_][A-Za-z0-9_]*)', re.IGNORECASE)
+
+
+def _parse_edge_mode(tb_definition: str) -> EdgeMode:
+  """Return EdgeMode for an edge `DEFINE TABLE` string.
+
+  `TYPE RELATION` wins. If absent, fall back to the same SCHEMAFULL/SCHEMALESS
+  keyword check `_parse_table_mode` uses; SCHEMALESS is the default when no
+  keyword is present.
+  """
+  if not tb_definition:
+    return EdgeMode.SCHEMALESS
+
+  if _TYPE_RELATION_PATTERN.search(tb_definition):
+    return EdgeMode.RELATION
+
+  definition_upper = tb_definition.upper()
+  if 'SCHEMAFULL' in definition_upper:
+    return EdgeMode.SCHEMAFULL
+  return EdgeMode.SCHEMALESS
+
+
+def _parse_edge_from_to(tb_definition: str) -> tuple[str | None, str | None]:
+  """Extract `FROM <table>` and `TO <table>` from an edge DEFINE TABLE string.
+
+  Returns ``(None, None)`` for non-RELATION edges or if either clause is
+  missing. The emitter requires both for RELATION mode, but this parser stays
+  permissive on read so a malformed live definition surfaces as missing-clause
+  drift instead of a parse failure.
+  """
+  if not tb_definition:
+    return (None, None)
+  from_match = _EDGE_FROM_PATTERN.search(tb_definition)
+  to_match = _EDGE_TO_PATTERN.search(tb_definition)
+  return (
+    from_match.group(1) if from_match else None,
+    to_match.group(1) if to_match else None,
+  )
 
 
 def _parse_table_mode(tb_definition: str) -> TableMode:

--- a/tests/test_edge_parser.py
+++ b/tests/test_edge_parser.py
@@ -1,0 +1,198 @@
+"""Tests for `parse_edge_info` round-trip + diff symmetry.
+
+`parse_edge_info` is the inverse of `generate_edge_sql` for the three
+EdgeDefinition modes (RELATION, SCHEMAFULL, SCHEMALESS). Each test builds a
+code-side EdgeDefinition, synthesizes the `INFO FOR TABLE` payload SurrealDB
+would return after applying the DEFINE statement, parses the payload back,
+and asserts the round-tripped value matches the code-side declaration (and
+that `diff_edges` against the proxy table-wrapped form returns no diffs).
+"""
+
+from __future__ import annotations
+
+from surql.migration.diff import diff_edges
+from surql.schema.edge import EdgeMode, edge_schema
+from surql.schema.fields import FieldType, datetime_field, int_field
+from surql.schema.parser import parse_edge_info
+from surql.schema.table import IndexDefinition, IndexType
+
+
+def _index(name: str, columns: list[str]) -> IndexDefinition:
+  return IndexDefinition(name=name, columns=columns, type=IndexType.STANDARD)
+
+
+def test_parse_relation_edge_minimal() -> None:
+  """`DEFINE TABLE likes TYPE RELATION FROM user TO post` round-trips."""
+  define_table = 'DEFINE TABLE likes TYPE RELATION FROM user TO post'
+  live = parse_edge_info(
+    'likes', {'fields': {}, 'indexes': {}, 'events': {}}, define_table=define_table
+  )
+  assert live.name == 'likes'
+  assert live.mode == EdgeMode.RELATION
+  assert live.from_table == 'user'
+  assert live.to_table == 'post'
+  assert live.fields == []
+  assert live.indexes == []
+  assert live.permissions is None
+
+
+def test_parse_relation_edge_strips_implicit_in_out_fields() -> None:
+  """SurrealDB auto-emits `in`/`out` fields for TYPE RELATION; parser drops them."""
+  define_table = 'DEFINE TABLE likes TYPE RELATION FROM user TO post'
+  # SurrealDB v3 would return these in INFO FOR TABLE for a RELATION edge.
+  fields_dict = {
+    'in': 'DEFINE FIELD in ON likes TYPE record<user> PERMISSIONS FULL',
+    'out': 'DEFINE FIELD out ON likes TYPE record<post> PERMISSIONS FULL',
+    'created_at': 'DEFINE FIELD created_at ON likes TYPE datetime DEFAULT time::now() PERMISSIONS FULL',
+  }
+  live = parse_edge_info('likes', {'fields': fields_dict}, define_table=define_table)
+  field_names = {f.name for f in live.fields}
+  assert 'in' not in field_names
+  assert 'out' not in field_names
+  assert 'created_at' in field_names
+
+
+def test_parse_schemafull_edge_keeps_in_out_fields() -> None:
+  """SCHEMAFULL edges declare `in`/`out` explicitly; parser must NOT strip them."""
+  define_table = 'DEFINE TABLE entity_relation SCHEMAFULL'
+  fields_dict = {
+    'in': 'DEFINE FIELD in ON entity_relation TYPE record<entity> PERMISSIONS FULL',
+    'out': 'DEFINE FIELD out ON entity_relation TYPE record<entity> PERMISSIONS FULL',
+  }
+  live = parse_edge_info('entity_relation', {'fields': fields_dict}, define_table=define_table)
+  assert live.mode == EdgeMode.SCHEMAFULL
+  field_names = {f.name for f in live.fields}
+  assert field_names == {'in', 'out'}
+
+
+def test_parse_schemaless_edge_mode() -> None:
+  define_table = 'DEFINE TABLE follows SCHEMALESS'
+  live = parse_edge_info('follows', {}, define_table=define_table)
+  assert live.mode == EdgeMode.SCHEMALESS
+  assert live.from_table is None
+  assert live.to_table is None
+
+
+def test_parse_relation_edge_with_permissions_round_trip() -> None:
+  """Per-action permissions on a RELATION edge parse back into the same dict."""
+  code = edge_schema(
+    'authored',
+    from_table='user',
+    to_table='post',
+    permissions={'create': '$auth.id = in', 'delete': '$auth.id = in'},
+  )
+  define_table = (
+    'DEFINE TABLE authored TYPE RELATION FROM user TO post '
+    'PERMISSIONS FOR create WHERE $auth.id = in FOR delete WHERE $auth.id = in'
+  )
+  live = parse_edge_info('authored', {}, define_table=define_table)
+  assert live.mode == EdgeMode.RELATION
+  assert live.from_table == 'user'
+  assert live.to_table == 'post'
+  assert live.permissions == code.permissions
+  assert diff_edges(live, code) == []
+
+
+def test_parse_relation_edge_with_extra_field_round_trips_via_diff_edges() -> None:
+  """An edge with a non-housekeeping field (weight) diffs clean against the code."""
+  code = edge_schema(
+    'likes',
+    from_table='user',
+    to_table='post',
+    fields=[int_field('weight', default='1')],
+  )
+  define_table = 'DEFINE TABLE likes TYPE RELATION FROM user TO post'
+  fields_dict = {
+    'in': 'DEFINE FIELD in ON likes TYPE record<user> PERMISSIONS FULL',
+    'out': 'DEFINE FIELD out ON likes TYPE record<post> PERMISSIONS FULL',
+    'weight': 'DEFINE FIELD weight ON likes TYPE int DEFAULT 1 PERMISSIONS FULL',
+  }
+  live = parse_edge_info('likes', {'fields': fields_dict}, define_table=define_table)
+  assert diff_edges(live, code) == []
+
+
+def test_parse_relation_edge_with_index_round_trips() -> None:
+  code = edge_schema(
+    'likes',
+    from_table='user',
+    to_table='post',
+    fields=[datetime_field('created_at', default='time::now()')],
+    indexes=[_index('likes_created_idx', ['created_at'])],
+  )
+  define_table = 'DEFINE TABLE likes TYPE RELATION FROM user TO post'
+  fields_dict = {
+    'created_at': 'DEFINE FIELD created_at ON likes TYPE datetime DEFAULT time::now() PERMISSIONS FULL',
+  }
+  indexes_dict = {
+    'likes_created_idx': 'DEFINE INDEX likes_created_idx ON likes FIELDS created_at',
+  }
+  live = parse_edge_info(
+    'likes',
+    {'fields': fields_dict, 'indexes': indexes_dict},
+    define_table=define_table,
+  )
+  assert diff_edges(live, code) == []
+
+
+def test_parse_edge_without_define_table_falls_back_to_legacy_tb_key() -> None:
+  """SurrealDB v2 carried the DEFINE TABLE string inside INFO FOR TABLE as `tb`."""
+  info = {
+    'tb': 'DEFINE TABLE likes TYPE RELATION FROM user TO post',
+    'fields': {},
+    'indexes': {},
+  }
+  live = parse_edge_info('likes', info)
+  assert live.mode == EdgeMode.RELATION
+  assert live.from_table == 'user'
+  assert live.to_table == 'post'
+
+
+def test_parse_edge_returns_none_endpoints_when_clauses_missing() -> None:
+  """Missing FROM/TO surfaces as None endpoints instead of a parse failure."""
+  define_table = 'DEFINE TABLE likes TYPE RELATION'
+  live = parse_edge_info('likes', {}, define_table=define_table)
+  assert live.mode == EdgeMode.RELATION
+  assert live.from_table is None
+  assert live.to_table is None
+
+
+def test_parse_edge_info_is_exported_from_schema_package() -> None:
+  from surql.schema import parse_edge_info as exported
+
+  assert exported is parse_edge_info
+
+
+def test_parse_edge_info_default_mode_when_define_table_empty() -> None:
+  """No DEFINE TABLE string defaults to SCHEMALESS — the safest fallback."""
+  live = parse_edge_info('orphan', {'fields': {}}, define_table='')
+  assert live.mode == EdgeMode.SCHEMALESS
+  assert live.fields == []
+
+
+def test_parse_edge_picks_up_field_with_nullable_record_type() -> None:
+  """Common shape on SCHEMAFULL edges: nullable record fields for endpoints."""
+  define_table = 'DEFINE TABLE rel SCHEMAFULL'
+  fields_dict = {
+    'in': 'DEFINE FIELD in ON rel TYPE none | record<entity> PERMISSIONS FULL',
+    'out': 'DEFINE FIELD out ON rel TYPE none | record<entity> PERMISSIONS FULL',
+  }
+  live = parse_edge_info('rel', {'fields': fields_dict}, define_table=define_table)
+  in_field = next(f for f in live.fields if f.name == 'in')
+  assert in_field.type == FieldType.RECORD
+  assert in_field.nullable is True
+  assert in_field.target_table == 'entity'
+
+
+def test_parse_edge_propagates_field_named_default_parsing_path() -> None:
+  """Edge with a custom field named `default` should not crash the clause splitter.
+
+  This mirrors the table-side regression test for the `_split_field_clauses`
+  fix in 1.6.2; the parser path for edges goes through the same helpers.
+  """
+  define_table = 'DEFINE TABLE likes TYPE RELATION FROM user TO post'
+  fields_dict = {
+    'default': 'DEFINE FIELD default ON likes TYPE bool DEFAULT false PERMISSIONS FULL',
+  }
+  live = parse_edge_info('likes', {'fields': fields_dict}, define_table=define_table)
+  default_field = next(f for f in live.fields if f.name == 'default')
+  assert default_field.type == FieldType.BOOL

--- a/uv.lock
+++ b/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "oneiriq-surql"
-version = "1.6.3"
+version = "1.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Adds `parse_edge_info(edge_name, info, define_table=None)` to
`surql.schema.parser` so drift detectors can round-trip edge tables
(`EdgeDefinition` / `edge_schema`) end-to-end the way they already
round-trip regular tables via `parse_table_info`.

Before 1.6.4, drift detectors could only check edges' presence/absence
by cross-referencing `ALL_EDGES.keys()` against `INFO FOR DB.tables`.
`parse_table_info` against an edge table returned a `TableDefinition`
with `mode=SCHEMALESS` and no edge-specific metadata — there was no way
to diff edge MODE, FROM/TO endpoints, or per-edge fields/indexes against
the live DB. With `parse_edge_info` plus the existing `diff_edges`, edge
round-trip parity sits on the same footing as table parity.

## What `parse_edge_info` covers

- All three edge modes: `RELATION`, `SCHEMAFULL`, `SCHEMALESS`.
- `FROM <table> TO <table>` clauses on `TYPE RELATION` edges.
- Per-action `PERMISSIONS` clause SurrealDB v3 emits on the table-level
  `DEFINE TABLE` statement (via the existing `_parse_table_permissions`).
- Field, index, and event shapes — reuses `_parse_fields`,
  `_parse_indexes`, `_parse_events` so every per-field shape the table
  parser already handles (typed record links, `option<X>`, FLEXIBLE,
  sub-fields, fields named `default`) round-trips the same way on edges.
- For `RELATION`-mode edges the auto-emitted `in` and `out` fields are
  stripped on parse so they do not surface as orphan diffs against a
  code-side `EdgeDefinition` that (correctly) does not declare them.

Exported from `surql.schema` alongside `parse_table_info` / `parse_db_info`.

## Test plan

- [x] 13 new round-trip tests in `tests/test_edge_parser.py` exercise all
      three modes, in/out stripping behaviour, permissions, indexes,
      `FROM`/`TO` absence (None endpoints surface as drift instead of a
      parse failure), nullable record-typed in/out on SCHEMAFULL edges,
      `parse_edge_info` exported from `surql.schema`, default mode when
      `define_table` is empty, and the field-named-`default` regression
      that motivated `_split_field_clauses` in 1.6.2.
- [x] Full suite: 2651 passed + 9 skipped + 2 xfailed (was 2638 + 9 + 2 in 1.6.3).
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] `mypy src/surql/schema/parser.py` clean.